### PR TITLE
update(Path): Add `equals`, `relativeTo`, `realPath`, and more.

### DIFF
--- a/docs/common.md
+++ b/docs/common.md
@@ -97,8 +97,10 @@ const relPath = new Path('some/path', '../move/around', 'again');
 
 The following methods are available on the class instance.
 
-- `append(...parts: string[]): Path` - Append path parts to the end of the current path and return a
-  new `Path` instance.
+- `append(...parts: PortablePath[]): Path` - Append path parts to the end of the current path and
+  return a new `Path` instance.
+- `equals(path: PortablePath): boolean` - Returns true if both paths are equal using strict
+  equality.
 - `ext(withoutPeriod?: boolean): string` - Return the extension (if applicable) with or without
   leading period.
 - `exists(): boolean` - Return true if the current path exists on the file system.
@@ -109,15 +111,16 @@ The following methods are available on the class instance.
   folder name.
 - `parent(): Path` - Return the parent folder as a new `Path` instance.
 - `path(): FilePath` - Return the current path as a normalized string.
-- `prepend(...parts: string[]): Path` - Prepend path parts to the beginning of the current path and
-  return a new `Path` instance.
+- `prepend(...parts: PortablePath[]): Path` - Prepend path parts to the beginning of the current
+  path and return a new `Path` instance.
+- `relativeTo(to: PortablePath): Path` - Return a new relative `Path` instance from the current
+  "from" path to the defined "to" path.
 - `toString(): FilePath` - Return the current path as a normalized string.
 
-By default, the `Path` class operates on the defined path parts as-is, and doesn't verify against
-the actual file system. If you would prefer to operate against real paths, use the `resolve()`
-method, which returns a new `Path` instance where the current path is
-[resolved against](https://nodejs.org/api/path.html#path_path_resolve_paths) the defined current
-working directory (`process.cwd()`).
+By default, the `Path` class operates on the defined path parts as-is. If you would prefer to
+operate against real or resolved paths, use the `realPath()` and `resolve()` methods respectively.
+The current path is [resolved against](https://nodejs.org/api/path.html#path_path_resolve_paths) the
+defined current working directory (`process.cwd()`).
 
 ```ts
 path.path(); // Possibly inaccurate

--- a/packages/common/src/Path.ts
+++ b/packages/common/src/Path.ts
@@ -112,6 +112,14 @@ export default class Path {
   }
 
   /**
+   * Return a new relative `Path` instance from the current
+   * "from" path to the defined "to" path.
+   */
+  relativeTo(to: PortablePath): Path {
+    return new Path(path.relative(this.path(), String(to)));
+  }
+
+  /**
    * Return a new `Path` instance where the current path is accurately
    * resolved against the defined current working directory.
    */

--- a/packages/common/src/Path.ts
+++ b/packages/common/src/Path.ts
@@ -112,6 +112,35 @@ export default class Path {
   }
 
   /**
+   * Returns a canonical path by resolving directories and symlinks.
+   */
+  // istanbul ignore next
+  realPath(): FilePath {
+    const filePath = this.path();
+
+    if (typeof fs.realpathSync.native === 'function') {
+      try {
+        return fs.realpathSync.native(filePath);
+      } catch {
+        // Skip
+      }
+    }
+
+    // @ts-ignore
+    const fsBinding = process.binding('fs');
+
+    if (fsBinding.realpath) {
+      try {
+        return fsBinding.realpath(filePath, 'utf8');
+      } catch {
+        // Skip
+      }
+    }
+
+    return fs.realpathSync(filePath);
+  }
+
+  /**
    * Return a new relative `Path` instance from the current
    * "from" path to the defined "to" path.
    */

--- a/packages/common/src/Path.ts
+++ b/packages/common/src/Path.ts
@@ -11,9 +11,9 @@ export default class Path {
 
   private stats: fs.Stats | null = null;
 
-  constructor(...parts: FilePath[]) {
+  constructor(...parts: PortablePath[]) {
     // Always use forward slashes for better interop
-    this.internalPath = path.normalize(path.join(...parts)).replace(/\\/gu, Path.SEP);
+    this.internalPath = path.normalize(path.join(...parts.map(String))).replace(/\\/gu, Path.SEP);
   }
 
   /**
@@ -35,7 +35,7 @@ export default class Path {
    * Append path parts to the end of the current path
    * and return a new `Path` instance.
    */
-  append(...parts: FilePath[]): Path {
+  append(...parts: PortablePath[]): Path {
     return new Path(this.internalPath, ...parts);
   }
 
@@ -107,7 +107,7 @@ export default class Path {
    * Prepend path parts to the beginning of the current path
    * and return a new `Path` instance.
    */
-  prepend(...parts: FilePath[]): Path {
+  prepend(...parts: PortablePath[]): Path {
     return new Path(...parts, this.internalPath);
   }
 

--- a/packages/common/src/Path.ts
+++ b/packages/common/src/Path.ts
@@ -40,6 +40,13 @@ export default class Path {
   }
 
   /**
+   * Returns true if both paths are equal using strict equality.
+   */
+  equals(filePath: PortablePath): boolean {
+    return this.path() === String(filePath);
+  }
+
+  /**
    * Return the extension (if applicable) with or without leading period.
    */
   ext(withoutPeriod: boolean = false): string {

--- a/packages/common/tests/Path.test.ts
+++ b/packages/common/tests/Path.test.ts
@@ -86,6 +86,20 @@ describe('Path', () => {
     });
   });
 
+  describe('equals()', () => {
+    it('returns true if a match', () => {
+      const path = new Path('foo/bar');
+
+      expect(path.equals('foo/bar')).toBe(true);
+    });
+
+    it('returns false if not a match', () => {
+      const path = new Path('foo/bar');
+
+      expect(path.equals(new Path('foo/qux'))).toBe(false);
+    });
+  });
+
   describe('exists()', () => {
     it('returns true if a folder', () => {
       const path = new Path(__dirname);

--- a/packages/common/tests/Path.test.ts
+++ b/packages/common/tests/Path.test.ts
@@ -19,16 +19,20 @@ describe('Path', () => {
       expect(Path.resolve('./foo')).toEqual(new Path(resolve('./foo')));
     });
 
-    it('returns instance resolved', () => {
-      const path = new Path('./foo');
-
-      expect(Path.resolve(path)).toEqual(new Path(resolve('./foo')));
+    it('returns an instance for a `Path`', () => {
+      expect(Path.resolve(new Path('./foo'))).toEqual(new Path(resolve('./foo')));
     });
   });
 
   describe('constructor()', () => {
     it('joins multiple parts', () => {
       const path = new Path('/foo/bar', '../baz', 'file.js');
+
+      expect(path.path()).toBe('/foo/baz/file.js');
+    });
+
+    it('joins multiple parts with `Path` instances', () => {
+      const path = new Path('/foo/bar', new Path('../baz'), Path.create('file.js'));
 
       expect(path.path()).toBe('/foo/baz/file.js');
     });
@@ -68,6 +72,17 @@ describe('Path', () => {
       expect(p1.path()).toBe('/foo/baz');
       expect(p2.path()).toBe('/foo/baz/qux/foo');
       expect(p3.path()).toBe('/foo/baz/qux/current');
+    });
+
+    it('appends with a `Path` instance', () => {
+      const p1 = new Path('/foo/bar', '../baz');
+
+      expect(p1.path()).toBe('/foo/baz');
+
+      const p2 = p1.append(new Path('qux/foo'));
+
+      expect(p1.path()).toBe('/foo/baz');
+      expect(p2.path()).toBe('/foo/baz/qux/foo');
     });
   });
 
@@ -215,6 +230,17 @@ describe('Path', () => {
       expect(p1.path()).toBe('/foo/baz');
       expect(p2.path()).toBe('qux/foo/foo/baz');
       expect(p3.path()).toBe('../current/qux/foo/foo/baz');
+    });
+
+    it('prepends with a `Path` instance', () => {
+      const p1 = new Path('/foo/bar', '../baz');
+
+      expect(p1.path()).toBe('/foo/baz');
+
+      const p2 = p1.prepend(new Path('qux/foo'));
+
+      expect(p1.path()).toBe('/foo/baz');
+      expect(p2.path()).toBe('qux/foo/foo/baz');
     });
   });
 

--- a/packages/common/tests/Path.test.ts
+++ b/packages/common/tests/Path.test.ts
@@ -218,6 +218,20 @@ describe('Path', () => {
     });
   });
 
+  describe('relativeTo()', () => {
+    it('returns relative path using a string', () => {
+      const from = new Path('/foo/bar/baz');
+
+      expect(from.relativeTo('/foo/qux')).toEqual(new Path('../../qux'));
+    });
+
+    it('returns relative path using a path', () => {
+      const from = new Path('/foo/bar/baz');
+
+      expect(from.relativeTo(new Path('/foo/qux'))).toEqual(new Path('../../qux'));
+    });
+  });
+
   describe('resolve()', () => {
     it('returns a new instance with path resolved to cwd', () => {
       const path = new Path('foo/bar/baz');


### PR DESCRIPTION
As the title states. Adding more utility methods, as well as updating the constructor, append, and prepend to accept `Path` instances.