### PR TITLE
update(Tool): Support `PortablePath` and `Path` in workspace methods.

### DIFF
--- a/packages/core/src/ModuleLoader.ts
+++ b/packages/core/src/ModuleLoader.ts
@@ -43,7 +43,7 @@ export default class ModuleLoader<Tm> {
    * Import a class definition from a Node module and instantiate the class
    * with the provided options object.
    */
-  importModule(name: string, args: any[] = []): Tm {
+  importModule(name: string | Path, args: any[] = []): Tm {
     const { typeName } = this;
     const { appName, scoped } = this.tool.options;
 
@@ -54,10 +54,10 @@ export default class ModuleLoader<Tm> {
     let moduleName;
 
     // File path
-    if (name.match(/^\.|\/|\\|[A-Z]:/u)) {
+    if (name instanceof Path || name.match(/^\.|\/|\\|[A-Z]:/u)) {
       this.debug('Locating %s from path %s', typeName, color.filePath(name));
 
-      modulesToAttempt.push(new Path(name).path());
+      modulesToAttempt.push(Path.create(name).path());
       isFilePath = true;
 
       // Module name

--- a/packages/core/src/Tool.ts
+++ b/packages/core/src/Tool.ts
@@ -9,7 +9,14 @@ import pluralize from 'pluralize';
 import mergeWith from 'lodash/mergeWith';
 import optimal, { bool, object, string, Blueprint } from 'optimal';
 import parseArgs, { Arguments, Options as ArgOptions } from 'yargs-parser';
-import { instanceOf, isEmpty, AbstractConstructor, Path, FilePath } from '@boost/common';
+import {
+  instanceOf,
+  isEmpty,
+  AbstractConstructor,
+  Path,
+  FilePath,
+  PortablePath,
+} from '@boost/common';
 import { Event } from '@boost/event';
 import { createDebugger, Debugger } from '@boost/debug';
 import { createLogger, Logger } from '@boost/log';
@@ -239,9 +246,9 @@ export default class Tool<
   /**
    * Create a workspace metadata object composed of absolute file paths.
    */
-  createWorkspaceMetadata(jsonPath: FilePath): WorkspaceMetadata {
+  createWorkspaceMetadata(jsonPath: PortablePath): WorkspaceMetadata {
     const metadata: any = {};
-    const filePath = new Path(jsonPath);
+    const filePath = Path.create(jsonPath);
     const pkgPath = filePath.parent();
     const wsPath = pkgPath.parent();
 
@@ -338,7 +345,7 @@ export default class Tool<
         }).map(ws => `${ws}/package.json`),
         {
           absolute: true,
-          cwd: root,
+          cwd: String(root),
         },
       )
       .map(filePath => ({
@@ -352,7 +359,7 @@ export default class Tool<
    * for the defined root.
    */
   getWorkspacePackagePaths(options: WorkspaceOptions = {}): FilePath[] {
-    const root = options.root || this.options.root;
+    const root = String(options.root || this.options.root);
 
     return glob.sync(this.getWorkspacePaths({ ...options, relative: true, root }), {
       absolute: !options.relative,
@@ -367,7 +374,7 @@ export default class Tool<
    * for the defined root.
    */
   getWorkspacePaths(options: WorkspaceOptions = {}): FilePath[] {
-    const rootPath = new Path(options.root || this.options.root);
+    const rootPath = Path.create(options.root || this.options.root);
     const pkgPath = rootPath.append('package.json');
     const lernaPath = rootPath.append('lerna.json');
     const workspacePaths = [];

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,5 +1,5 @@
 import { Blueprint, Predicates } from 'optimal';
-import { AbstractConstructor } from '@boost/common';
+import { AbstractConstructor, PortablePath } from '@boost/common';
 import ModuleLoader from './ModuleLoader';
 
 export { Blueprint, Predicates };
@@ -114,5 +114,5 @@ export interface WorkspacePackageConfig extends PackageConfig {
 
 export interface WorkspaceOptions {
   relative?: boolean;
-  root?: string;
+  root?: PortablePath;
 }


### PR DESCRIPTION
Pretty self-explanatory and useful.