### PR TITLE
update: Buffer logs until rendering is complete.

### DIFF
--- a/configs/jest.js
+++ b/configs/jest.js
@@ -1,5 +1,5 @@
 module.exports = {
-  coveragePathIgnorePatterns: ['cli/src/Wrapper.tsx'],
+  coveragePathIgnorePatterns: ['testing.ts', 'cli/src/Wrapper.tsx'],
   coverageThreshold: {
     global: {
       branches: 85,

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -645,6 +645,11 @@ export default class ConfigCommand extends Command {
 }
 ```
 
+While React is rendering, all logs, either through the CLI [logger](#logging) or the native
+`console`, will be buffered until the rendering process is complete. Once complete, all buffered
+logs will be written to the terminal. This is necessary so that logs do not interrupt or tear the
+rendering loop.
+
 ### Shorthand Commands
 
 Sometimes classes may be overkill for commands, so Boost offers a feature known as shorthand
@@ -826,8 +831,8 @@ function CustomComponent() {
 }
 ```
 
-> It's highly encouraged to use this logging layer instead of the native console, so that logged
-> messages do not interrupt any React rendering process!
+> It's highly encouraged to use the logger instead of the native console, so that logged messages do
+> not interrupt the React rendering process, and write to the configured streams!
 
 ### Themes
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -844,6 +844,7 @@ operate properly. Because of this, not all Ink components can be used, except fo
 
 - [Box](https://github.com/vadimdemedes/ink#box)
 - [Color](https://github.com/vadimdemedes/ink#color)
+- [Static](https://github.com/vadimdemedes/ink#static)
 - [Text](https://github.com/vadimdemedes/ink#text)
 
 For convenience, these components can be imported from the Boost CLI package. This is preferred so

--- a/packages/cli/src/LogBuffer.ts
+++ b/packages/cli/src/LogBuffer.ts
@@ -2,32 +2,18 @@
 
 import { StreamType } from './types';
 
-type BufferListener = (buffer: string[]) => void;
 type UnwrapHandler = () => void;
 type ConsoleMethod = keyof typeof console;
 
-const NOTIFY_DELAY = 150;
 const CONSOLE_METHODS: { [K in StreamType]: ConsoleMethod[] } = {
-  stderr: [],
-  stdout: [
-    'debug',
-    'log',
-    'info',
-    // Until ink supports stderr
-    'error',
-    'trace',
-    'warn',
-  ],
+  stderr: ['error', 'trace', 'warn'],
+  stdout: ['debug', 'log', 'info'],
 };
 
 export default class LogBuffer {
   logs: string[] = [];
 
-  protected listener?: BufferListener;
-
   protected stream: NodeJS.WriteStream;
-
-  protected timer?: NodeJS.Timeout;
 
   protected type: StreamType;
 
@@ -42,30 +28,10 @@ export default class LogBuffer {
 
   flush = () => {
     if (this.logs.length > 0) {
-      if (this.listener) {
-        this.listener(this.logs);
-      } else {
-        this.logs.forEach(this.writeToStream);
-      }
-
+      this.logs.forEach(this.writeToStream);
       this.logs = [];
     }
-
-    if (this.timer) {
-      clearTimeout(this.timer);
-      delete this.timer;
-    }
   };
-
-  off() {
-    this.flush();
-
-    delete this.listener;
-  }
-
-  on(listener: BufferListener) {
-    this.listener = listener;
-  }
 
   unwrap() {
     this.flush();
@@ -92,27 +58,15 @@ export default class LogBuffer {
   }
 
   write = (message: string) => {
-    // `Static` will render each item in the array as a new line,
-    // so trim surrounding new lines here
     const msg =
       typeof String.prototype.trimEnd === 'function'
         ? String(message).trimEnd()
         : String(message).trim(); // Node 8
 
-    // If not wrapping the console, just output immediately
-    if (!this.wrapped) {
+    if (this.wrapped) {
+      this.logs.push(msg);
+    } else {
       this.writeToStream(msg);
-
-      return;
-    }
-
-    // Static component will render each item in the array as a new line,
-    // so trim surrounding new lines here
-    this.logs.push(msg);
-
-    // Place in a short timeout so that we can batch
-    if (!this.timer) {
-      this.timer = setTimeout(this.flush, NOTIFY_DELAY);
     }
   };
 

--- a/packages/cli/src/Program.tsx
+++ b/packages/cli/src/Program.tsx
@@ -103,8 +103,7 @@ export default class Program extends CommandManager<ProgramOptions> {
     this.outBuffer = new LogBuffer('stdout', this.streams.stdout);
 
     this.logger = createLogger({
-      // Use outBuffer until ink supports stderr
-      stderr: this.outBuffer,
+      stderr: this.errBuffer,
       stdout: this.outBuffer,
     });
 
@@ -338,13 +337,7 @@ export default class Program extends CommandManager<ProgramOptions> {
       this.rendering = true;
 
       const output = await render(
-        <Wrapper
-          errBuffer={this.errBuffer}
-          exit={this.exit}
-          logger={this.logger}
-          outBuffer={this.outBuffer}
-          program={this.options}
-        >
+        <Wrapper exit={this.exit} logger={this.logger} program={this.options}>
           {result || null}
         </Wrapper>,
         {

--- a/packages/cli/src/Program.tsx
+++ b/packages/cli/src/Program.tsx
@@ -109,6 +109,14 @@ export default class Program extends CommandManager<ProgramOptions> {
 
     this.onAfterRegister.listen(this.handleAfterRegister);
     this.onBeforeRegister.listen(this.handleBeforeRegister);
+
+    // istanbul ignore next
+    if (process.env.NODE_ENV !== 'test') {
+      process.on('SIGINT', () => {
+        this.errBuffer.unwrap();
+        this.outBuffer.unwrap();
+      });
+    }
   }
 
   blueprint({ string }: Predicates) {
@@ -350,6 +358,7 @@ export default class Program extends CommandManager<ProgramOptions> {
       );
 
       // This never resolves while testing
+      // istanbul ignore next
       if (!env('CLI_TEST_ONLY')) {
         await output.waitUntilExit();
       }

--- a/packages/cli/src/Program.tsx
+++ b/packages/cli/src/Program.tsx
@@ -111,12 +111,12 @@ export default class Program extends CommandManager<ProgramOptions> {
     this.onBeforeRegister.listen(this.handleBeforeRegister);
 
     // istanbul ignore next
-    if (process.env.NODE_ENV !== 'test') {
-      process.on('SIGINT', () => {
-        this.errBuffer.unwrap();
-        this.outBuffer.unwrap();
-      });
-    }
+    // if (process.env.NODE_ENV !== 'test') {
+    //   process.on('SIGINT', () => {
+    //     this.errBuffer.unwrap();
+    //     this.outBuffer.unwrap();
+    //   });
+    // }
   }
 
   blueprint({ string }: Predicates) {

--- a/packages/cli/src/Wrapper.tsx
+++ b/packages/cli/src/Wrapper.tsx
@@ -1,73 +1,40 @@
 import React from 'react';
-import { Box, Static } from 'ink';
+import { Box } from 'ink';
 import { Logger } from '@boost/log';
 import Failure from './Failure';
 import ProgramContext from './ProgramContext';
 import { ProgramOptions, ExitHandler } from './types';
-import LogBuffer from './LogBuffer';
 
 export interface WrapperProps {
-  errBuffer: LogBuffer;
   exit: ExitHandler;
   logger: Logger;
-  outBuffer: LogBuffer;
   program: ProgramOptions;
 }
 
 export interface WrapperState {
-  errLogs: string[];
   error: Error | null;
-  outLogs: string[];
 }
 
 export default class Wrapper extends React.Component<WrapperProps, WrapperState> {
   state: WrapperState = {
-    errLogs: [],
     error: null,
-    outLogs: [],
-  };
-
-  wrapped = {
-    stderr: false,
-    stdout: false,
   };
 
   static getDerivedStateFromError(error: Error) {
     return { error };
   }
 
-  componentDidMount() {
-    this.props.errBuffer.on(errLogs => {
-      this.setState(prev => ({
-        errLogs: prev.errLogs.concat(errLogs),
-      }));
-    });
-
-    this.props.outBuffer.on(outLogs => {
-      this.setState(prev => ({
-        outLogs: prev.outLogs.concat(outLogs),
-      }));
-    });
-  }
-
-  componentWillUnmount() {
-    this.props.errBuffer.off();
-    this.props.outBuffer.off();
-  }
-
   render() {
-    const { error, outLogs } = this.state;
+    const { error } = this.state;
     const { children, exit, logger, program } = this.props;
 
     return (
       <Box>
         <ProgramContext.Provider value={{ exit, log: logger, program }}>
-          <Static>{outLogs}</Static>
-
           {error ? (
             <Failure binName={program.bin} delimiter={program.delimiter} error={error} />
           ) : (
-            <Box>{children}</Box>
+            children
           )}
         </ProgramContext.Provider>
       </Box>

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,7 +3,17 @@
  * @license     https://opensource.org/licenses/MIT
  */
 
-import { Box, Color, Text, useInput, useStdin, useStdout, StdinProps, StdoutProps } from 'ink';
+import {
+  Box,
+  Color,
+  Text,
+  Static,
+  useInput,
+  useStdin,
+  useStdout,
+  StdinProps,
+  StdoutProps,
+} from 'ink';
 import Command from './Command';
 import Failure from './Failure';
 import Header from './Header';
@@ -19,7 +29,7 @@ export * from './helpers';
 export * from './types';
 
 // Ink
-export { Box, Color, Text, useInput, useStdin, useStdout, StdinProps, StdoutProps };
+export { Box, Color, Text, Static, useInput, useStdin, useStdout, StdinProps, StdoutProps };
 
 // Boost
 export { Command, Failure, Header, Help, IndexHelp, Program, ProgramContext, Style };

--- a/packages/cli/src/testing.ts
+++ b/packages/cli/src/testing.ts
@@ -125,9 +125,16 @@ export async function runProgram(
   program: Program,
   argv: string[],
 ): Promise<{ code: ExitCode; output: string; outputStripped: string }> {
+  if (!(program.streams.stderr instanceof MockWriteStream)) {
+    program.streams.stderr = (new MockWriteStream() as unknown) as NodeJS.WriteStream;
+  }
+
   if (!(program.streams.stdout instanceof MockWriteStream)) {
-    // @ts-ignore Allow override
-    program.streams = mockStreams();
+    program.streams.stdout = (new MockWriteStream() as unknown) as NodeJS.WriteStream;
+  }
+
+  if (!(program.streams.stdin instanceof MockReadStream)) {
+    program.streams.stdin = (new MockReadStream() as unknown) as NodeJS.ReadStream;
   }
 
   // Ink async rendering never resolves while testing,
@@ -139,7 +146,9 @@ export async function runProgram(
 
   env('CLI_TEST_ONLY', null);
 
-  const output = ((program.streams.stdout as unknown) as MockWriteStream).get();
+  const output =
+    ((program.streams.stdout as unknown) as MockWriteStream).get() +
+    ((program.streams.stderr as unknown) as MockWriteStream).get();
 
   return {
     code,

--- a/packages/cli/tests/LogBuffer.test.ts
+++ b/packages/cli/tests/LogBuffer.test.ts
@@ -1,11 +1,5 @@
 import LogBuffer from '../src/LogBuffer';
 
-function sleep(delay: number = 250) {
-  return new Promise(resolve => {
-    setTimeout(resolve, delay);
-  });
-}
-
 describe('LogBuffer', () => {
   let buffer: LogBuffer;
 
@@ -29,35 +23,15 @@ describe('LogBuffer', () => {
     expect(console.info).toEqual(original);
   });
 
-  it('calls listener when logs are flushed', async () => {
-    const spy = jest.fn();
-
-    buffer.on(spy);
-    buffer.wrap();
-    buffer.write('foo');
-    buffer.write('bar');
-    buffer.write('baz');
-
-    await sleep();
-
-    expect(spy).toHaveBeenCalledTimes(1);
-    expect(spy).toHaveBeenCalledWith(['foo', 'bar', 'baz']);
-    expect(buffer.logs).toEqual([]);
-  });
-
-  it('calls native stream when flushed and no listener defined', async () => {
+  it('writes to native stream when flushed', () => {
     const spy = jest.fn();
     const logSpy = jest.spyOn(process.stdout, 'write').mockImplementation();
 
-    buffer.on(spy);
-    buffer.off(); // Test this
     buffer.wrap();
-
     buffer.write('foo');
     buffer.write('bar');
     buffer.write('baz');
-
-    await sleep();
+    buffer.unwrap();
 
     expect(spy).toHaveBeenCalledTimes(0);
     expect(logSpy).toHaveBeenCalledTimes(3);
@@ -69,21 +43,17 @@ describe('LogBuffer', () => {
     logSpy.mockRestore();
   });
 
-  it('calls native stream when flushed and no listener defined (stderr)', async () => {
+  it('writes to native stream when flushed (stderr)', () => {
     buffer = new LogBuffer('stderr', process.stderr);
 
     const spy = jest.fn();
     const logSpy = jest.spyOn(process.stderr, 'write').mockImplementation();
 
-    buffer.on(spy);
-    buffer.off(); // Test this
     buffer.wrap();
-
     buffer.write('foo');
     buffer.write('bar');
     buffer.write('baz');
-
-    await sleep();
+    buffer.unwrap();
 
     expect(spy).toHaveBeenCalledTimes(0);
     expect(logSpy).toHaveBeenCalledTimes(3);
@@ -111,5 +81,12 @@ describe('LogBuffer', () => {
     expect(spy).toHaveBeenCalledWith('Yup\n');
 
     spy.mockRestore();
+  });
+
+  it('logs a message if wrapped', () => {
+    buffer.wrap();
+    buffer.write('Yup\n');
+
+    expect(buffer.logs).toEqual(['Yup']);
   });
 });

--- a/packages/cli/tests/LogBuffer.test.ts
+++ b/packages/cli/tests/LogBuffer.test.ts
@@ -84,9 +84,14 @@ describe('LogBuffer', () => {
   });
 
   it('logs a message if wrapped', () => {
+    const spy = jest.spyOn(process.stdout, 'write').mockImplementation();
+
     buffer.wrap();
     buffer.write('Yup\n');
 
     expect(buffer.logs).toEqual(['Yup']);
+
+    buffer.unwrap();
+    spy.mockRestore();
   });
 });

--- a/packages/cli/tests/Program.test.tsx
+++ b/packages/cli/tests/Program.test.tsx
@@ -1066,6 +1066,11 @@ describe('<Program />', () => {
       }
     }
 
+    beforeEach(() => {
+      stdout.append = true;
+      stderr.append = true;
+    });
+
     it('handles logging when rendering a component', async () => {
       const logSpy = jest.spyOn(stdout, 'write');
       const errSpy = jest.spyOn(stderr, 'write');
@@ -1075,7 +1080,7 @@ describe('<Program />', () => {
       const { code, output } = await runProgram(program, ['log', '--component']);
 
       expect(logSpy).toHaveBeenCalled();
-      expect(errSpy).not.toHaveBeenCalled(); // Until ink supports stderr
+      expect(errSpy).toHaveBeenCalled();
       expect(output).toMatchSnapshot();
       expect(code).toBe(0);
 
@@ -1092,7 +1097,7 @@ describe('<Program />', () => {
       const { code, output } = await runProgram(program, ['log']);
 
       expect(logSpy).toHaveBeenCalled();
-      expect(errSpy).not.toHaveBeenCalled(); // Until ink supports stderr
+      expect(errSpy).toHaveBeenCalled();
       expect(output).toMatchSnapshot();
       expect(code).toBe(0);
 

--- a/packages/cli/tests/__snapshots__/Program.test.tsx.snap
+++ b/packages/cli/tests/__snapshots__/Program.test.tsx.snap
@@ -347,13 +347,25 @@ exports[`<Program /> locale errors for invalid \`--locale\` 1`] = `
 `;
 
 exports[`<Program /> logging handles logging when rendering a component 1`] = `
-"Component log
+"Log
+[35mtrace[39m Trace
+[36minfo[39m Info
+Returned from component!Component log
+[90mdebug[39m Debug
+[33mwarn[39m Warn
+[31merror[39m Error
 [31merror[39m Component error
-Returned from component!"
+"
 `;
 
 exports[`<Program /> logging handles logging when returning a string 1`] = `
-"Returned from command!
+"Log
+[35mtrace[39m Trace
+[36minfo[39m Info
+Returned from command!
+[90mdebug[39m Debug
+[33mwarn[39m Warn
+[31merror[39m Error
 "
 `;
 
@@ -398,8 +410,8 @@ exports[`<Program /> success can return an element that writes with ink 1`] = `"
 
 exports[`<Program /> tasks runs a sync task correctly 1`] = `
 "Hi
-[31merror[39m Bye
 15
+[31merror[39m Bye
 "
 `;
 


### PR DESCRIPTION
Before, we would buffer all logs while React is rendering and flush to `Static` at intervals. This worked but was kind of hacky. It also consumed `Static`, which we can only have 1 of, and now consumers couldn't use it.

Now it buffers all logs while React is rendering and doesn't flush them till the render is complete.