### PR TITLE
breaking: Refactor config setting structure.

### DIFF
--- a/packages/plugin/src/Loader.ts
+++ b/packages/plugin/src/Loader.ts
@@ -1,7 +1,14 @@
 /* eslint-disable security/detect-non-literal-regexp */
 
 import path from 'path';
-import { PathResolver, requireModule, ModuleName, isObject, MODULE_NAME_PART } from '@boost/common';
+import {
+  PathResolver,
+  requireModule,
+  ModuleName,
+  isObject,
+  isFilePath,
+  MODULE_NAME_PART,
+} from '@boost/common';
 import { createDebugger, Debugger } from '@boost/debug';
 import { color } from '@boost/internal';
 import { Pluggable, Factory } from './types';
@@ -23,6 +30,7 @@ export default class Loader<Plugin extends Pluggable> {
    * Create a path resolver that will attempt to find a plugin at a defined Node module,
    * based on a list of acceptable plugin module name patterns.
    */
+  // eslint-disable-next-line complexity
   createResolver(name: ModuleName): PathResolver {
     const resolver = new PathResolver();
     const { singularName: typeName, projectName } = this.registry;
@@ -33,7 +41,7 @@ export default class Loader<Plugin extends Pluggable> {
     this.debug('Resolving possible %s modules', color.symbol(typeName));
 
     // Absolute or relative file path
-    if (path.isAbsolute(name) || name.charAt(0) === '.') {
+    if (isFilePath(name) && (path.isAbsolute(name) || name.charAt(0) === '.')) {
       this.debug('Found a file path: %s', color.filePath(name));
 
       resolver.lookupFilePath(name);

--- a/packages/plugin/src/Registry.ts
+++ b/packages/plugin/src/Registry.ts
@@ -13,7 +13,7 @@ import {
   Pluggable,
   Registration,
   Setting,
-  PluginOptions,
+  RegisterOptions,
   Callback,
 } from './types';
 import { DEFAULT_PRIORITY } from './constants';
@@ -24,7 +24,7 @@ export default class Registry<Plugin extends Pluggable, Tool = unknown> extends 
   readonly debug: Debugger;
 
   // Emits after a plugin is loaded but before its registered
-  readonly onLoad = new Event<[Setting<Plugin>, object?]>('load');
+  readonly onLoad = new Event<[string, object]>('load');
 
   // Emits after a plugin is registered
   readonly onRegister = new Event<[Plugin]>('register');
@@ -107,57 +107,58 @@ export default class Registry<Plugin extends Pluggable, Tool = unknown> extends 
   }
 
   /**
-   * Load and register a single plugin based on a setting. The possible setting variants are:
-   *
-   * - If a string, will load based on module name or file path.
-   * - If an array, the 1st item will be considered the module name or file path,
-   *    and the 2nd item an options object that will be passed to the factory function.
-   *    A 3rd object can be provided to customize priority.
-   * - If an object or class instance, will assume to be the plugin itself.
+   * Load and register a single plugin by name, or with an explicit instance.
    */
-  async load(setting: Setting<Plugin>, options?: object, tool?: Tool): Promise<Plugin> {
-    const opts: PluginOptions = {};
+  async load(
+    name: ModuleName | Plugin,
+    params: object = {},
+    options: RegisterOptions<Tool> = {},
+  ): Promise<Plugin> {
     let plugin: Plugin;
 
-    // Module name
-    if (typeof setting === 'string') {
-      plugin = await this.loader.load(setting, options);
+    // Plugin instance
+    if (isObject(name)) {
+      plugin = name;
 
-      // Module name with options
-    } else if (Array.isArray(setting)) {
-      plugin = await this.loader.load(setting[0], setting[1] || options);
-
-      if (isObject(setting[2])) {
-        Object.assign(opts, setting[2]);
+      if (plugin.priority) {
+        // eslint-disable-next-line no-param-reassign
+        options.priority = plugin.priority;
       }
 
-      // Plugin directly
-    } else if (isObject<Plugin>(setting)) {
-      if (setting.name) {
-        plugin = setting;
+      // Options object
+    } else if (typeof name === 'string') {
+      plugin = await this.loader.load(name, params);
 
-        if (setting.priority) {
-          opts.priority = setting.priority;
-        }
-      } else {
-        throw new PluginError('PLUGIN_REQUIRED_NAME');
-      }
+      this.onLoad.emit([name, params]);
 
       // Unknown setting
     } else {
-      throw new PluginError('SETTING_UNKNOWN', [setting]);
+      throw new PluginError('SETTING_UNKNOWN', [name]);
     }
 
-    this.onLoad.emit([setting, options]);
+    if (!plugin.name) {
+      throw new PluginError('PLUGIN_REQUIRED_NAME');
+    }
 
-    return this.register(plugin.name, plugin, tool, opts);
+    return this.register(plugin.name, plugin, options.tool, options);
   }
 
   /**
    * Load and register multiple plugins based on a list of settings.
    */
-  async loadMany(settings: Setting<Plugin>[], tool?: Tool): Promise<Plugin[]> {
-    return Promise.all(settings.map((setting) => this.load(setting, {}, tool)));
+  async loadMany(
+    settings: (ModuleName | Plugin)[] | Setting,
+    options: RegisterOptions<Tool> = {},
+  ): Promise<Plugin[]> {
+    if (Array.isArray(settings)) {
+      return Promise.all(settings.map((setting) => this.load(setting, {}, options)));
+    }
+
+    return Promise.all(
+      Object.entries(settings)
+        .filter(([name, setting]) => setting !== false && setting !== undefined)
+        .map(([name, setting]) => this.load(name, isObject(setting) ? setting : {}, options)),
+    );
   }
 
   /**
@@ -179,8 +180,8 @@ export default class Registry<Plugin extends Pluggable, Tool = unknown> extends 
   async register(
     name: ModuleName,
     plugin: Plugin,
-    tool?: Tool,
-    options?: PluginOptions,
+    tool: Tool | undefined = undefined,
+    { priority }: RegisterOptions<Tool> = {},
   ): Promise<Plugin> {
     if (!name.match(MODULE_NAME_PATTERN)) {
       throw new PluginError('MODULE_NAME_INVALID', [this.pluralName]);
@@ -199,10 +200,9 @@ export default class Registry<Plugin extends Pluggable, Tool = unknown> extends 
     await this.triggerStartup(plugin, tool);
 
     this.plugins.push({
-      priority: DEFAULT_PRIORITY,
-      ...options,
       name,
       plugin,
+      priority: priority ?? DEFAULT_PRIORITY,
     });
 
     this.debug('Sorting plugins by priority');

--- a/packages/plugin/src/types.ts
+++ b/packages/plugin/src/types.ts
@@ -1,10 +1,6 @@
-import { ModuleName, FilePath } from '@boost/common';
+import { ModuleName } from '@boost/common';
 
 export type Callback<T = unknown> = (value: T) => void | Promise<void>;
-
-export interface PluginOptions {
-  priority?: number;
-}
 
 export interface Pluggable<T = unknown> {
   name: ModuleName;
@@ -13,17 +9,20 @@ export interface Pluggable<T = unknown> {
   startup?: Callback<T>;
 }
 
-export type Setting<T extends Pluggable> =
-  | ModuleName
-  | FilePath
-  | [ModuleName | FilePath, object, PluginOptions?]
-  | T;
+export interface Setting {
+  [name: string]: boolean | object;
+}
 
 export type Factory<T extends Pluggable, O extends object = object> = (
   options: Partial<O>,
 ) => T | Promise<T>;
 
-export interface Registration<T extends Pluggable> extends PluginOptions {
+export interface RegisterOptions<T = unknown> {
+  priority?: number;
+  tool?: T;
+}
+
+export interface Registration<T extends Pluggable> extends RegisterOptions {
   name: ModuleName;
   plugin: T;
 }

--- a/packages/plugin/tests/Registry.test.ts
+++ b/packages/plugin/tests/Registry.test.ts
@@ -148,7 +148,7 @@ describe('Registry', () => {
 
       registry.onLoad.listen(spy);
 
-      await registry.loadMany(['foo', 'bar'], tool);
+      await registry.loadMany(['foo', 'bar'], { tool });
 
       expect(spy).toHaveBeenCalledTimes(2);
       expect(spy).toHaveBeenCalledWith('foo', {});
@@ -173,7 +173,7 @@ describe('Registry', () => {
           // Full name with custom scope
           '@test/boost-test-renderer-baz',
         ],
-        tool,
+        { tool },
       );
 
       // @ts-expect-error
@@ -206,7 +206,7 @@ describe('Registry', () => {
       ]);
     });
 
-    it('loads plugins based on name with options and priority', async () => {
+    it('loads plugins using an object with options', async () => {
       fixtures.push(
         copyFixtureToNodeModule('plugin-renderer-object', 'boost-test-renderer-foo'),
         copyFixtureToNodeModule('plugin-renderer-object', '@boost-test/renderer-bar'),
@@ -214,39 +214,41 @@ describe('Registry', () => {
       );
 
       await registry.loadMany(
-        [
+        {
           // Short names
-          ['foo', { value: 'foo' }, { priority: 3 }],
+          foo: { value: 'foo' },
           // Full names
-          ['@boost-test/renderer-bar', { value: 'bar' }, { priority: 2 }],
-          // Full name with shorthand scope
-          ['@test/baz', { value: 'baz' }, { priority: 1 }],
-        ],
-        tool,
+          '@boost-test/renderer-bar': { value: 'bar' },
+          // Full name enabled
+          '@test/baz': true,
+          // Short name disabled
+          qux: false,
+        },
+        { tool },
       );
 
       // @ts-expect-error
       expect(registry.plugins).toEqual([
         {
-          name: '@test/boost-test-renderer-baz',
+          name: 'boost-test-renderer-foo',
           plugin: expect.objectContaining({
-            options: { value: 'baz' },
+            options: { value: 'foo' },
           }),
-          priority: 1,
+          priority: 100,
         },
         {
           name: '@boost-test/renderer-bar',
           plugin: expect.objectContaining({
             options: { value: 'bar' },
           }),
-          priority: 2,
+          priority: 100,
         },
         {
-          name: 'boost-test-renderer-foo',
+          name: '@test/boost-test-renderer-baz',
           plugin: expect.objectContaining({
-            options: { value: 'foo' },
+            options: {},
           }),
-          priority: 3,
+          priority: 100,
         },
       ]);
     });
@@ -262,7 +264,6 @@ describe('Registry', () => {
           // @ts-expect-error
           { name: '@boost-test/renderer-bar', options: { value: 'bar' }, render },
           // With options and priority
-          // @ts-expect-error
           { name: '@test/boost-test-renderer-baz', options: { value: 'baz' }, priority: 1, render },
         ],
         {},
@@ -303,7 +304,7 @@ describe('Registry', () => {
       const baz = createClass('@test/boost-test-renderer-baz', { value: 'baz' });
       baz.priority = 1;
 
-      await registry.loadMany([foo, bar, baz], tool);
+      await registry.loadMany([foo, bar, baz], { tool });
 
       // @ts-expect-error
       expect(registry.plugins).toEqual([
@@ -325,57 +326,6 @@ describe('Registry', () => {
       ]);
     });
 
-    it('supports all the patterns at once', async () => {
-      fixtures.push(
-        copyFixtureToNodeModule('plugin-renderer-object', 'boost-test-renderer-foo'),
-        copyFixtureToNodeModule('plugin-renderer-object', '@boost-test/renderer-bar'),
-        copyFixtureToNodeModule('plugin-renderer-object', '@test/boost-test-renderer-baz'),
-      );
-
-      await registry.loadMany(
-        [
-          'foo',
-          ['@boost-test/renderer-bar', { value: 'bar' }],
-          {
-            name: '@test/boost-test-renderer-baz',
-            priority: 1,
-            render: () => 'test',
-          },
-          createClass('boost-test-renderer-qux', { value: 'qux' }),
-        ],
-        tool,
-      );
-
-      const qux = new Renderer({ value: 'qux' });
-      qux.name = 'boost-test-renderer-qux';
-
-      // @ts-expect-error
-      expect(registry.plugins).toEqual([
-        {
-          name: '@test/boost-test-renderer-baz',
-          plugin: expect.any(Object),
-          priority: 1,
-        },
-        {
-          name: 'boost-test-renderer-qux',
-          plugin: qux,
-          priority: DEFAULT_PRIORITY,
-        },
-        {
-          name: 'boost-test-renderer-foo',
-          plugin: expect.any(Object),
-          priority: DEFAULT_PRIORITY,
-        },
-        {
-          name: '@boost-test/renderer-bar',
-          plugin: expect.objectContaining({
-            options: { value: 'bar' },
-          }),
-          priority: DEFAULT_PRIORITY,
-        },
-      ]);
-    });
-
     it('errors if unsupported setting passed', async () => {
       await expect(
         registry.loadMany(
@@ -391,17 +341,15 @@ describe('Registry', () => {
     it('errors if object is passed without a name', async () => {
       await expect(
         registry.loadMany(
-          [
-            // @ts-expect-error
-            {},
-          ],
+          // @ts-expect-error
+          [{}],
           {},
         ),
       ).rejects.toThrow('Plugin object or class instance found without a `name` property.');
     });
 
     it('errors if class instance is passed without a name', async () => {
-      await expect(registry.loadMany([new Renderer()], tool)).rejects.toThrow(
+      await expect(registry.loadMany([new Renderer()], { tool })).rejects.toThrow(
         'Plugin object or class instance found without a `name` property.',
       );
     });


### PR DESCRIPTION
Now matches `@boost/config`.