### PR TITLE
new: Add support for `loose` mode.

### DIFF
--- a/packages/args/src/helpers/expandShortOption.ts
+++ b/packages/args/src/helpers/expandShortOption.ts
@@ -4,8 +4,16 @@ import { AliasMap, ShortOptionName, LongOptionName } from '../types';
 /**
  * Expand a short option name to a long option name.
  */
-export default function expandShortOption(short: ShortOptionName, map: AliasMap): LongOptionName {
+export default function expandShortOption(
+  short: ShortOptionName,
+  map: AliasMap,
+  loose: boolean,
+): LongOptionName {
   if (!map[short]) {
+    if (loose) {
+      return short;
+    }
+
     throw new ArgsError('SHORT_UNKNOWN', [short]);
   }
 

--- a/packages/args/src/helpers/processShortOptionGroup.ts
+++ b/packages/args/src/helpers/processShortOptionGroup.ts
@@ -12,19 +12,25 @@ export default function processShortOptionGroup(
   configs: OptionConfigMap,
   options: OptionMap,
   map: AliasMap,
+  loose: boolean,
 ) {
   group.split('').forEach((short) => {
-    const name = expandShortOption(short as ShortOptionName, map);
+    const name = expandShortOption(short as ShortOptionName, map, loose);
     const config = configs[name];
 
-    if (!config || config.type === 'string') {
+    // Loose mode, always be a flag
+    if (loose && !config) {
+      options[name] = true;
+
+      // Unknown option
+    } else if (!config || config.type === 'string') {
       throw new ArgsError('GROUP_UNSUPPORTED_TYPE');
 
-      // Flag
+      // Boolean option, flag
     } else if (config.type === 'boolean') {
       options[name] = true;
 
-      // Number counter
+      // Number option, counter
     } else if (config.type === 'number') {
       if (config.count) {
         options[name] = Number(options[name]) + 1;

--- a/packages/args/src/parse.ts
+++ b/packages/args/src/parse.ts
@@ -58,6 +58,7 @@ export default function parse<O extends object = {}, P extends PrimitiveType[] =
 ): Arguments<O, P> {
   const {
     commands: commandConfigs = [],
+    loose: looseMode = false,
     options: optionConfigs,
     params: paramConfigs = [],
     unknown: allowUnknown = false,
@@ -80,7 +81,7 @@ export default function parse<O extends object = {}, P extends PrimitiveType[] =
     }
 
     // Set an unknown value
-    if (currentScope.unknown) {
+    if (currentScope.unknown && !looseMode) {
       if (allowUnknown) {
         unknown[currentScope.name] =
           currentScope.value === undefined ? DEFAULT_STRING_VALUE : String(currentScope.finalValue);
@@ -156,7 +157,11 @@ export default function parse<O extends object = {}, P extends PrimitiveType[] =
 
           // Short option "-f"
         } else if (isShortOption(optionName)) {
-          optionName = expandShortOption(optionName.slice(1) as ShortOptionName, mapping);
+          optionName = expandShortOption(
+            optionName.slice(1) as ShortOptionName,
+            mapping,
+            looseMode,
+          );
 
           // Long option "--foo"
         } else if (isLongOption(optionName)) {
@@ -167,7 +172,7 @@ export default function parse<O extends object = {}, P extends PrimitiveType[] =
         const scope = createScope(optionName, optionConfigs, options);
 
         // Unknown option found, handle accordingly
-        if (scope.unknown && !allowUnknown) {
+        if (scope.unknown && !allowUnknown && !looseMode) {
           checker.checkUnknownOption(arg);
 
           // Flag found, so set value immediately and discard scope

--- a/packages/args/src/parse.ts
+++ b/packages/args/src/parse.ts
@@ -80,16 +80,25 @@ export default function parse<O extends object = {}, P extends PrimitiveType[] =
       return;
     }
 
-    // Set an unknown value
-    if (currentScope.unknown && !looseMode) {
+    const { name, value, finalValue } = currentScope;
+
+    // Support loose mode
+    if (looseMode) {
+      if (value === undefined) {
+        options[name] = !currentScope.negated;
+      } else {
+        options[name] = finalValue;
+      }
+
+      // Set an unknown value
+    } else if (currentScope.unknown) {
       if (allowUnknown) {
-        unknown[currentScope.name] =
-          currentScope.value === undefined ? DEFAULT_STRING_VALUE : String(currentScope.finalValue);
+        unknown[name] = value === undefined ? DEFAULT_STRING_VALUE : String(finalValue);
       }
 
       // Set and cast value if defined
-    } else if (currentScope.value !== undefined) {
-      options[currentScope.name] = currentScope.finalValue;
+    } else if (value !== undefined) {
+      options[name] = finalValue;
     }
 
     currentScope = null;
@@ -151,7 +160,7 @@ export default function parse<O extends object = {}, P extends PrimitiveType[] =
         if (isShortOptionGroup(optionName)) {
           checker.checkNoInlineValue(inlineValue);
 
-          processShortOptionGroup(optionName.slice(1), optionConfigs, options, mapping);
+          processShortOptionGroup(optionName.slice(1), optionConfigs, options, mapping, looseMode);
 
           continue;
 

--- a/packages/args/src/types.ts
+++ b/packages/args/src/types.ts
@@ -102,12 +102,17 @@ export interface Arguments<O extends object, P extends PrimitiveType[] = ArgList
   unknown: UnknownOptionMap;
 }
 
-export interface ParserOptions<O extends object, P extends PrimitiveType[] = ArgList> {
+export interface ParserSettings {
+  loose?: boolean;
+  unknown?: boolean;
+  variadic?: boolean;
+}
+
+export interface ParserOptions<O extends object, P extends PrimitiveType[] = ArgList>
+  extends ParserSettings {
   commands?: string[] | CommandChecker;
   options: MapOptionConfig<O>;
   params?: MapParamConfig<P>;
-  unknown?: boolean;
-  variadic?: boolean;
 }
 
 // BASE TYPES

--- a/packages/args/tests/parse.test.ts
+++ b/packages/args/tests/parse.test.ts
@@ -2483,4 +2483,96 @@ describe('parse()', () => {
       });
     });
   });
+
+  describe('loose mode', () => {
+    it('supports unknown short option and flags', () => {
+      const result = parse(['-F', '-k', 'value', '--no-G'], {
+        loose: true,
+        options: {},
+      });
+
+      expect(result).toEqual({
+        command: [],
+        errors: [],
+        options: {
+          F: true,
+          G: false,
+          k: 'value',
+        },
+        params: [],
+        rest: [],
+        unknown: {},
+      });
+    });
+
+    it('supports unknown short option and flags alongside configured options', () => {
+      const result = parse(['foo', '--opt', 'val', '-F', '-k', 'value', '--no-G'], {
+        loose: true,
+        options: {
+          opt: optConfig,
+        },
+      });
+
+      expect(result).toEqual({
+        command: [],
+        errors: [],
+        options: {
+          F: true,
+          G: false,
+          k: 'value',
+          opt: 'val',
+        },
+        params: ['foo'],
+        rest: [],
+        unknown: {},
+      });
+    });
+
+    it('supports unknown short options in groups', () => {
+      const result = parse(['-FkG'], {
+        loose: true,
+        options: {},
+      });
+
+      expect(result).toEqual({
+        command: [],
+        errors: [],
+        options: {
+          F: true,
+          G: true,
+          k: true,
+        },
+        params: [],
+        rest: [],
+        unknown: {},
+      });
+    });
+
+    it('supports unknown short options in groups alongside configured options', () => {
+      const result = parse<{ flag: boolean; num: number }>(['-FnnG'], {
+        loose: true,
+        options: {
+          flag: flagConfig,
+          num: {
+            ...numConfigExpanded,
+            default: 0,
+            count: true,
+          },
+        },
+      });
+
+      expect(result).toEqual({
+        command: [],
+        errors: [],
+        options: {
+          G: true,
+          flag: true,
+          num: 2,
+        },
+        params: [],
+        rest: [],
+        unknown: {},
+      });
+    });
+  });
 });

--- a/packages/args/tests/parse.test.ts
+++ b/packages/args/tests/parse.test.ts
@@ -2175,6 +2175,24 @@ describe('parse()', () => {
       });
     });
 
+    it('doesnt error for an unknown short option with value is provided in loose mode', () => {
+      const result = parse(['foo', '-U', 'value'], {
+        loose: true,
+        options: {},
+      });
+
+      expect(result).toEqual({
+        command: [],
+        errors: [],
+        options: {
+          U: 'value',
+        },
+        params: ['foo'],
+        rest: [],
+        unknown: {},
+      });
+    });
+
     it('errors if an unknown short option with inline value is provided', () => {
       const result = parse(['foo', '-U=value'], {
         options: {},

--- a/packages/args/tests/parse.test.ts
+++ b/packages/args/tests/parse.test.ts
@@ -2527,7 +2527,7 @@ describe('parse()', () => {
     });
 
     it('supports unknown short option and flags', () => {
-      const result = parse(['-F', '-k', 'value', '--no-G'], {
+      const result = parse(['-F', '-k', 'value', '--no-G', '--k2=value'], {
         loose: true,
         options: {},
       });
@@ -2538,6 +2538,7 @@ describe('parse()', () => {
         options: {
           F: true,
           G: false,
+          k2: 'value',
           k: 'value',
         },
         params: [],

--- a/packages/args/tests/parse.test.ts
+++ b/packages/args/tests/parse.test.ts
@@ -2485,6 +2485,47 @@ describe('parse()', () => {
   });
 
   describe('loose mode', () => {
+    it('supports unknown options', () => {
+      const result = parse(['--key', 'value', '--inline=value'], {
+        loose: true,
+        options: {},
+      });
+
+      expect(result).toEqual({
+        command: [],
+        errors: [],
+        options: {
+          inline: 'value',
+          key: 'value',
+        },
+        params: [],
+        rest: [],
+        unknown: {},
+      });
+    });
+
+    it('supports unknown options alongside configured options', () => {
+      const result = parse<{ opt: string }>(['--key', 'value', '--inline=value', '--opt', '123'], {
+        loose: true,
+        options: {
+          opt: optConfig,
+        },
+      });
+
+      expect(result).toEqual({
+        command: [],
+        errors: [],
+        options: {
+          inline: 'value',
+          key: 'value',
+          opt: '123',
+        },
+        params: [],
+        rest: [],
+        unknown: {},
+      });
+    });
+
     it('supports unknown short option and flags', () => {
       const result = parse(['-F', '-k', 'value', '--no-G'], {
         loose: true,
@@ -2506,12 +2547,15 @@ describe('parse()', () => {
     });
 
     it('supports unknown short option and flags alongside configured options', () => {
-      const result = parse(['foo', '--opt', 'val', '-F', '-k', 'value', '--no-G'], {
-        loose: true,
-        options: {
-          opt: optConfig,
+      const result = parse<{ opt: string }>(
+        ['foo', '--opt', 'val', '-F', '-k', 'value', '--no-G'],
+        {
+          loose: true,
+          options: {
+            opt: optConfig,
+          },
         },
-      });
+      );
 
       expect(result).toEqual({
         command: [],

--- a/website/docs/args.mdx
+++ b/website/docs/args.mdx
@@ -22,6 +22,7 @@ A type-safe and convention based argument parsing library, with strict validatio
 >
   <TabItem value="yarn">
 
+
 ```bash
 yarn add @boost/args
 ```
@@ -29,12 +30,14 @@ yarn add @boost/args
   </TabItem>
   <TabItem value="npm">
 
+
 ```bash
 npm install @boost/args
 ```
 
   </TabItem>
 </Tabs>
+
 
 ## Parsing
 
@@ -535,6 +538,35 @@ const args = parse<{ color: string }>(argv, {
 ```
 
 > Command categories only pertain to the `Command` interface type.
+
+### Loose mode
+
+When loose mode is enabled, the following changes to the parser are made:
+
+- Unknown options will be typed as strings and set into the `options` return object. This supersedes
+  the `unknown` setting as it works differently.
+- Short options without a configured parent will no longer throw an error, and will be set into the
+  `options` return object.
+  - When no value is provided, they will be typed as `boolean`, otherwise as `string`.
+  - When found in a short option group, they will be typed as `boolean`.
+
+```ts
+const argv = ['-F', 'k=value', '--legit', 'foo', '--unknown', 'bar'];
+const args = parse<{ legit: string }>(argv, {
+  loose: true,
+  options: {
+    legit: {
+      description: 'A legitimate option',
+      type: 'string',
+    },
+  },
+});
+
+args.options; // { F: true, k: 'value', legit: 'foo', unknown: 'bar' }
+args.unknown; // {}
+```
+
+> This mode should only be used for interoperability with other argument parsers.
 
 ## Type casting
 


### PR DESCRIPTION
Sometimes we need to interop with third-party parsers.