### PR TITLE
fix: Fix validation breaking transport instances.

### DIFF
--- a/packages/log/src/Logger.ts
+++ b/packages/log/src/Logger.ts
@@ -3,9 +3,10 @@ import util from 'util';
 import { Contract, Predicates, Blueprint } from '@boost/common';
 import { env } from '@boost/internal';
 import ConsoleTransport from './transports/ConsoleTransport';
+import Transport from './Transport';
 import debug from './debug';
 import { DEFAULT_LABELS, LOG_LEVELS } from './constants';
-import { LoggerOptions, LogLevel, Formatter, Transportable, LogMetadata } from './types';
+import { LoggerOptions, LogLevel, LogMetadata } from './types';
 
 export default class Logger extends Contract<LoggerOptions> {
   protected silent: boolean = false;
@@ -24,20 +25,19 @@ export default class Logger extends Contract<LoggerOptions> {
     );
   }
 
-  blueprint({ array, func, object, shape, string }: Predicates): Blueprint<LoggerOptions> {
+  blueprint({
+    array,
+    func,
+    instance,
+    object,
+    shape,
+    string,
+  }: Predicates): Blueprint<LoggerOptions> {
     return {
       labels: object(string()),
       metadata: object(),
       name: string().required().notEmpty(),
-      transports: array(
-        shape({
-          format: func<Formatter>().notNullable(),
-          // eslint-disable-next-line react/forbid-prop-types
-          levels: array(string<LogLevel>()),
-          write: func<Transportable['write']>().notNullable(),
-        }),
-        [new ConsoleTransport()],
-      ),
+      transports: array(instance(Transport).notNullable(), [new ConsoleTransport()]),
     };
   }
 

--- a/packages/log/src/transports/StreamTransport.ts
+++ b/packages/log/src/transports/StreamTransport.ts
@@ -7,6 +7,14 @@ export interface StreamTransportOptions extends TransportOptions {
 }
 
 export default class StreamTransport extends Transport<StreamTransportOptions> {
+  protected stream: Writable;
+
+  constructor(options: StreamTransportOptions) {
+    super(options);
+
+    this.stream = options.stream;
+  }
+
   blueprint(preds: Predicates): Blueprint<StreamTransportOptions> {
     const { func, shape } = preds;
 
@@ -19,6 +27,6 @@ export default class StreamTransport extends Transport<StreamTransportOptions> {
   }
 
   write(message: string) {
-    this.options.stream.write(message);
+    this.stream.write(message);
   }
 }


### PR DESCRIPTION
The log packages seems to crash when using file/stream transports, as demonstrated below.

```ts
import { createLogger, StreamTransport } from '@boost/log';
import chalk from 'chalk';


const transport = new StreamTransport({
    levels: ['error', 'warn'],
    stream: process.stderr,
  });

const log = createLogger({ 
    name: 'network_logger',
    labels: {
        error: chalk.bgRed.white.bold(' ERROR '),
        info: chalk.bgGreen.white.bold(' INFO '),
        debug: chalk.bgBlue.white.bold(' DEBUG ')
    },
    transports: [
        transport
    ]
});

log.error('Something has happened…');
```

```
C:\Users\08cro\Desktop\loggerTest\node_modules\@boost\log\lib\index.js:354
    const stream = this.open();
                        ^

TypeError: this.open is not a function
    at Object.write (C:\Users\08cro\Desktop\loggerTest\node_modules\@boost\log\lib\index.js:354:25)
    at C:\Users\08cro\Desktop\loggerTest\node_modules\@boost\log\lib\index.js:225:24
    at Array.forEach (<anonymous>)
    at Logger.log (C:\Users\08cro\Desktop\loggerTest\node_modules\@boost\log\lib\index.js:223:29)
    at Function.<anonymous> (C:\Users\08cro\Desktop\loggerTest\node_modules\@boost\log\lib\index.js:242:12)
    at file:///C:/Users/08cro/Desktop/loggerTest/index.js:22:5
    at ModuleJob.run (internal/modules/esm/module_job.js:152:23)
    at async Loader.import (internal/modules/esm/loader.js:166:24)
    at async Object.loadESM (internal/process/esm_loader.js:68:5)
```

This is very odd since tests pass, but that's probably a side-effect of mocking.

Turns out the problem is `optimal` and its validation. When checking `shape`s, it rebuilds the object and returns a new value. But since these are class instances, its completely destroying them and removing `this` and other inherited methods. 

This PR is a temporary workaround until the upstream `optimal` is fixed.