### PR TITLE
new: Add `Command#render` to render components continuously.

### DIFF
--- a/packages/cli/src/Command.tsx
+++ b/packages/cli/src/Command.tsx
@@ -129,6 +129,25 @@ export default abstract class Command<
   }
 
   /**
+   * Create a React element based on the Help component.
+   */
+  createHelp(): React.ReactElement {
+    const metadata = this.getMetadata();
+
+    return (
+      <Help
+        categories={metadata.categories}
+        config={metadata}
+        commands={mapCommandMetadata(metadata.commands)}
+        delimiter={this[INTERNAL_PROGRAM]?.options.delimiter}
+        header={metadata.path}
+        options={metadata.options}
+        params={metadata.params}
+      />
+    );
+  }
+
+  /**
    * Execute a system native command with the given arguments
    * and pass the results through a promise. This does *not* execute Boost CLI
    * commands, use `runProgram()` instead.
@@ -222,22 +241,10 @@ export default abstract class Command<
   }
 
   /**
-   * Render a help menu for the current command.
+   * Render a React element with Ink and output to the configured streams.
    */
-  renderHelp(): React.ReactElement {
-    const metadata = this.getMetadata();
-
-    return (
-      <Help
-        categories={metadata.categories}
-        config={metadata}
-        commands={mapCommandMetadata(metadata.commands)}
-        delimiter={this[INTERNAL_PROGRAM]?.options.delimiter}
-        header={metadata.path}
-        options={metadata.options}
-        params={metadata.params}
-      />
-    );
+  async render(element: React.ReactElement) {
+    return this.getProgram().renderElement(element);
   }
 
   /**
@@ -274,7 +281,7 @@ export default abstract class Command<
   abstract run(...params: P): RunResult | Promise<RunResult>;
 
   /**
-   * Return the program instance of fail.
+   * Return the program instance or fail.
    */
   private getProgram(): Program {
     const program = this[INTERNAL_PROGRAM];

--- a/packages/cli/src/test.ts
+++ b/packages/cli/src/test.ts
@@ -48,11 +48,11 @@ export class MockWriteStream {
   off() {}
 }
 
-export function mockStreams(): ProgramStreams {
+export function mockStreams(append?: boolean): ProgramStreams {
   return ({
-    stderr: new MockWriteStream(),
+    stderr: new MockWriteStream(append),
     stdin: new MockReadStream(),
-    stdout: new MockWriteStream(),
+    stdout: new MockWriteStream(append),
   } as unknown) as ProgramStreams;
 }
 

--- a/packages/cli/src/test.ts
+++ b/packages/cli/src/test.ts
@@ -150,13 +150,14 @@ export function runTask<A extends unknown[], R, T extends TaskContext>(
 export async function runProgram(
   program: Program,
   argv: string[],
+  { append }: { append?: boolean } = {},
 ): Promise<{ code: ExitCode; output: string; outputStripped: string }> {
   if (!(program.streams.stderr instanceof MockWriteStream)) {
-    program.streams.stderr = (new MockWriteStream() as unknown) as NodeJS.WriteStream;
+    program.streams.stderr = (new MockWriteStream(append) as unknown) as NodeJS.WriteStream;
   }
 
   if (!(program.streams.stdout instanceof MockWriteStream)) {
-    program.streams.stdout = (new MockWriteStream() as unknown) as NodeJS.WriteStream;
+    program.streams.stdout = (new MockWriteStream(append) as unknown) as NodeJS.WriteStream;
   }
 
   if (!(program.streams.stdin instanceof MockReadStream)) {

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -130,10 +130,11 @@ export interface CommandMetadataMap {
 }
 
 export interface Commandable<O extends object = any, P extends PrimitiveType[] = any[]> {
+  createHelp: () => string | React.ReactElement;
   getMetadata: () => CommandMetadata;
   getParserOptions: () => ParserOptions<O, P>;
   getPath: () => CommandPath;
-  renderHelp: () => string | React.ReactElement;
+  render: (element: React.ReactElement) => Promise<void>;
   run: (...params: P) => RunResult | Promise<RunResult>;
 }
 

--- a/packages/cli/tests/Program.test.tsx
+++ b/packages/cli/tests/Program.test.tsx
@@ -1633,7 +1633,7 @@ describe('<Program />', () => {
 
         this.log.error('After');
 
-        await this.render(<Comp>Baz</Comp>);
+        return <Comp>Baz</Comp>;
       }
     }
 

--- a/packages/cli/tests/Program.test.tsx
+++ b/packages/cli/tests/Program.test.tsx
@@ -85,11 +85,10 @@ describe('<Program />', () => {
   let stderr: MockWriteStream;
   let stdout: MockWriteStream;
   let stdin: MockReadStream;
-  let appendOutput = false;
 
-  beforeEach(() => {
-    stderr = new MockWriteStream(appendOutput);
-    stdout = new MockWriteStream(appendOutput);
+  function createProgram(append?: boolean) {
+    stderr = new MockWriteStream(append);
+    stdout = new MockWriteStream(append);
     stdin = new MockReadStream();
     program = new Program(
       {
@@ -103,10 +102,10 @@ describe('<Program />', () => {
         stdin: (stdin as unknown) as NodeJS.ReadStream,
       },
     );
-  });
+  }
 
-  afterEach(() => {
-    appendOutput = false;
+  beforeEach(() => {
+    createProgram();
   });
 
   it('errors if bin is not kebab case', () => {
@@ -1632,16 +1631,14 @@ describe('<Program />', () => {
 
         await this.render(<Comp>Bar</Comp>);
 
-        this.log.warn('Middle');
+        this.log.error('After');
 
         await this.render(<Comp>Baz</Comp>);
-
-        this.log.error('After');
       }
     }
 
     beforeEach(() => {
-      appendOutput = true;
+      createProgram(true);
     });
 
     it('renders and outputs multiple component renders', async () => {

--- a/packages/cli/tests/__snapshots__/Program.test.tsx.snap
+++ b/packages/cli/tests/__snapshots__/Program.test.tsx.snap
@@ -19,6 +19,11 @@ Boost v1.2.3 [90mboost[39m
 "
 `;
 
+exports[`<Program /> components renders and outputs multiple component renders 1`] = `
+"[31merror[39m After
+"
+`;
+
 exports[`<Program /> default command executes default when no args passed 1`] = `
 "Build!
 "

--- a/packages/cli/tests/__snapshots__/Program.test.tsx.snap
+++ b/packages/cli/tests/__snapshots__/Program.test.tsx.snap
@@ -20,7 +20,9 @@ Boost v1.2.3 [90mboost[39m
 `;
 
 exports[`<Program /> components renders and outputs multiple component renders 1`] = `
-"[31merror[39m After
+"Before
+Foo[36minfo[39m Middle
+BarBaz[31merror[39m After
 "
 `;
 

--- a/website/docs/cli.mdx
+++ b/website/docs/cli.mdx
@@ -31,7 +31,6 @@ handling ANSI escape sequences and terminal widths can be tedious and complicate
 >
   <TabItem value="yarn">
 
-
 ```bash
 yarn add @boost/cli react ink
 ```
@@ -39,14 +38,12 @@ yarn add @boost/cli react ink
   </TabItem>
   <TabItem value="npm">
 
-
 ```bash
 npm install @boost/cli react ink
 ```
 
   </TabItem>
 </Tabs>
-
 
 ## Environment variables
 
@@ -319,7 +316,6 @@ define static class properties of the same name!
 >
   <TabItem value="decl">
 
-
 ```ts
 import { Command, Config } from '@boost/cli';
 
@@ -332,7 +328,6 @@ export default class BuildCommand extends Command {}
 
   </TabItem>
   <TabItem value="imp">
-
 
 ```ts
 import { Command } from '@boost/cli';
@@ -350,7 +345,6 @@ export default class BuildCommand extends Command {
 
   </TabItem>
 </Tabs>
-
 
 ![Command example](/img/cli/command.png)
 
@@ -382,7 +376,6 @@ easier type safety, the `Options` collection type can be used to type the static
   ]}
 >
   <TabItem value="decl">
-
 
 ```ts
 import { Command, Arg, GlobalOptions } from '@boost/cli';
@@ -421,7 +414,6 @@ export default class CustomCommand extends Command<CustomOptions> {
 
   </TabItem>
   <TabItem value="imp">
-
 
 ```ts
 import { Command, GlobalOptions, Options } from '@boost/cli';
@@ -488,7 +480,6 @@ export default class CustomCommand extends Command<CustomOptions> {
   </TabItem>
 </Tabs>
 
-
 ![Options example](/img/cli/options.png)
 
 #### Unknown options
@@ -507,7 +498,6 @@ will be set as a string object to the `Command#unknown` class property.
 >
   <TabItem value="decl">
 
-
 ```ts
 import { Command, GlobalOptions, Config } from '@boost/cli';
 
@@ -522,7 +512,6 @@ export default class CustomCommand extends Command<GlobalOptions> {
 
   </TabItem>
   <TabItem value="imp">
-
 
 ```ts
 import { Command, GlobalOptions } from '@boost/cli';
@@ -543,7 +532,6 @@ export default class CustomCommand extends Command<GlobalOptions> {
 
   </TabItem>
 </Tabs>
-
 
 ![Unknown option example](/img/cli/unknown-option.png)
 
@@ -583,7 +571,6 @@ type safety, the `Params` collection type can be used to type the static propert
 >
   <TabItem value="decl">
 
-
 ```ts
 import { Command, Arg, GlobalOptions } from '@boost/cli';
 
@@ -618,7 +605,6 @@ export default class CustomCommand extends Command<GlobalOptions, CustomParams> 
   </TabItem>
   <TabItem value="imp">
 
-
 ```ts
 import { Command, Params, GlobalOptions } from '@boost/cli';
 
@@ -654,7 +640,6 @@ export default class CustomCommand extends Command<GlobalOptions, CustomParams> 
   </TabItem>
 </Tabs>
 
-
 ![Params example](/img/cli/params.png)
 
 #### Variadic params
@@ -675,7 +660,6 @@ Using the example above, it would look like the following.
 >
   <TabItem value="decl">
 
-
 ```ts
 import { Command, Config, Arg, GlobalOptions } from '@boost/cli';
 
@@ -694,7 +678,6 @@ export default class CustomCommand extends Command<GlobalOptions, CustomParams> 
 
   </TabItem>
   <TabItem value="imp">
-
 
 ```ts
 import { Command, Params, GlobalOptions } from '@boost/cli';
@@ -720,7 +703,6 @@ export default class CustomCommand extends Command<GlobalOptions, CustomParams> 
 
   </TabItem>
 </Tabs>
-
 
 ![Variadic params example](/img/cli/variadic-params.png)
 
@@ -767,11 +749,12 @@ Sub-commands can now be executed on the command line by passing their full path,
 ### Rendering components
 
 This chapter assumes you have knowledge of [React][react], JSX/TSX, and [Ink][ink]. If you do not,
-it's highly encouraged to study those topics, but React is not necessarily a requirement (can use
-[logging](#logging)). With that being said, return React elements from `Command#run()` to render the
-component output to the CLI.
+it's highly encouraged to study those topics, but building CLIs with React is not necessarily a
+requirement as you can use [logging](#logging) instead.
 
-For a quick demonstration, let's implement a component that writes to a file asynchronously.
+With that being said, components can be rendered from a command by returning a React element from
+`Command#run()`, or by calling the `Command#render()` method. For a quick demonstration, let's
+implement a component that writes to a file asynchronously.
 
 ```tsx
 import fs from 'fs';
@@ -833,10 +816,16 @@ export default class ConfigCommand extends Command {
   async run(path: string) {
     const data = await loadConfigFromSomeSource();
 
+    await this.render(<WriteConfig data={data} path={path} />);
+
+    // Or...
     return <WriteConfig data={data} path={path} />;
   }
 }
 ```
+
+Using the `render()` method allows for multiple and or different components to be rendered within
+the same run cycle. Returning a component will only use 1. However, both can be used together!
 
 ### Shorthand registration
 
@@ -962,7 +951,6 @@ program.categories({
 >
   <TabItem value="decl">
 
-
 ```ts
 import { Command, Config } from '@boost/cli';
 
@@ -982,7 +970,6 @@ export default class CustomCommand extends Command {
 
   </TabItem>
   <TabItem value="imp">
-
 
 ```ts
 import { Command, Categories } from '@boost/cli';
@@ -1007,7 +994,6 @@ export default class CustomCommand extends Command {
   </TabItem>
 </Tabs>
 
-
 Categories are sorted by weight first, then alphabetical second, so define `weight` when you want
 strict control of the category order. Uncategorized items have a weight of `0`, and the built-in
 globals have a weight of `100`.
@@ -1024,7 +1010,6 @@ using the `category` setting! Here's an example using decorators.
   ]}
 >
   <TabItem value="decl">
-
 
 ```ts
 import { Command, Config, Arg, GlobalOptions } from '@boost/cli';
@@ -1044,7 +1029,6 @@ export default class BuildCommand extends Command<BuildOptions> {
 
   </TabItem>
   <TabItem value="imp">
-
 
 ```ts
 import { Command, Options, GlobalOptions } from '@boost/cli';
@@ -1076,7 +1060,6 @@ export default class BuildCommand extends Command<BuildOptions> {
 
   </TabItem>
 </Tabs>
-
 
 ## Logging
 

--- a/website/docs/cli/testing.md
+++ b/website/docs/cli/testing.md
@@ -7,7 +7,7 @@ The following [Jest](https://github.com/facebook/jest) utilities are available i
 
 ## `mockStreams`
 
-> mockStreams(): ProgramStreams
+> mockStreams(append?: boolean): ProgramStreams
 
 Returns mocked `stderr`, `stdout`, and `stdin` streams that can be passed to a `Program`. This does
 not mock all stream functionality, only those required by Boost and Ink.


### PR DESCRIPTION
This allows multiple and or different components to be rendered when running a command.