### PR TITLE
fix: Use `where` instead of `which`. Improve Windows support.

### DIFF
--- a/packages/debug/src/CrashReporter.ts
+++ b/packages/debug/src/CrashReporter.ts
@@ -123,12 +123,12 @@ export default class CrashReporter {
         if (!version) {
           version = extractVersion(run(bin, ['version']));
         }
+
+        if (version) {
+          this.add(languages[bin!], version, resolveHome(run('which', [bin])));
+        }
       } catch {
         // Ignore
-      }
-
-      if (version) {
-        this.add(languages[bin!], version, resolveHome(run('which', [bin])));
       }
     });
 

--- a/packages/debug/src/CrashReporter.ts
+++ b/packages/debug/src/CrashReporter.ts
@@ -9,7 +9,13 @@ import { FilePath, PackageStructure, PortablePath, requireModule, toArray } from
 import debug from './debug';
 
 function run(command: string, args: string[]): string {
-  return String(execa.sync(command, args, { preferLocal: true }).stdout);
+  let cmd = command;
+
+  if (command === 'where' && os.platform() === 'win32') {
+    cmd += '.exe';
+  }
+
+  return String(execa.sync(cmd, args, { preferLocal: true }).stdout);
 }
 
 function resolveHome(filePath: FilePath): string {
@@ -64,7 +70,7 @@ export default class CrashReporter {
         this.add(
           bins[bin as keyof typeof bins],
           extractVersion(run(bin, ['--version'])),
-          resolveHome(run('which', [bin])),
+          resolveHome(run('where', [bin])),
         );
       } catch {
         // Ignore
@@ -125,7 +131,7 @@ export default class CrashReporter {
         }
 
         if (version) {
-          this.add(languages[bin!], version, resolveHome(run('which', [bin])));
+          this.add(languages[bin!], version, resolveHome(run('where', [bin])));
         }
       } catch {
         // Ignore

--- a/packages/debug/tests/CrashReporter.test.ts
+++ b/packages/debug/tests/CrashReporter.test.ts
@@ -23,7 +23,7 @@ describe('CrashReporter', () => {
 
       return {
         stderr: '',
-        stdout: command === 'which' ? `/${args.join(' ')}` : '0.0.0',
+        stdout: command === 'where' ? `/${args.join(' ')}` : '0.0.0',
       };
     });
 

--- a/packages/debug/tests/CrashReporter.test.ts
+++ b/packages/debug/tests/CrashReporter.test.ts
@@ -23,7 +23,7 @@ describe('CrashReporter', () => {
 
       return {
         stderr: '',
-        stdout: command === 'where' ? `/${args.join(' ')}` : '0.0.0',
+        stdout: command.includes('where') ? `/${args.join(' ')}` : '0.0.0',
       };
     });
 


### PR DESCRIPTION
`which` doesn't work in all environments, but `where` does.