### PR TITLE
new: Support tuples (source and options) for plugin settings.

### DIFF
--- a/packages/config/src/Cache.ts
+++ b/packages/config/src/Cache.ts
@@ -10,10 +10,10 @@ export interface FileCache<T> {
 export default class Cache {
   configDir?: Path;
 
-  dirFilesCache: { [dir: string]: Path[] } = {};
+  dirFilesCache: Record<string, Path[]> = {};
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  fileContentCache: { [path: string]: FileCache<any> } = {};
+  fileContentCache: Record<string, FileCache<any>> = {};
 
   pkgPath?: Path;
 

--- a/packages/config/src/helpers/mergePlugins.ts
+++ b/packages/config/src/helpers/mergePlugins.ts
@@ -3,13 +3,14 @@ import { PluginsSetting, PluginsSettingList, PluginsSettingMap } from '../types'
 import mergeObject from './mergeObject';
 
 function convertListToMap(list: PluginsSettingList): PluginsSettingMap {
-  return list.reduce(
-    (map, name) => ({
+  return list.reduce((map, entry) => {
+    const [name, options = true] = Array.isArray(entry) ? entry : [entry];
+
+    return {
       ...map,
-      [name]: true,
-    }),
-    {},
-  );
+      [name]: options,
+    };
+  }, {});
 }
 
 export default function mergePlugins(

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -26,4 +26,5 @@ export {
   mergePlugins,
   overwrite,
 };
+
 export type { ConfigErrorCode };

--- a/packages/config/src/predicates.ts
+++ b/packages/config/src/predicates.ts
@@ -3,8 +3,8 @@ import {
   ExtendsSetting,
   FileGlob,
   OverridesSettingItem,
+  PluginOptions,
   PluginsSetting,
-  PluginsSettingMapItem,
 } from './types';
 
 export function createExtendsPredicate(preds: Predicates = predicates) {
@@ -14,13 +14,13 @@ export function createExtendsPredicate(preds: Predicates = predicates) {
 }
 
 export function createPluginsPredicate(preds: Predicates = predicates) {
-  const { array, bool, object, string, union } = preds;
+  const { array, bool, object, string, tuple, union } = preds;
+  const pluginSource = string().notEmpty();
+  const pluginOptions = union<PluginOptions>([bool(), object().notNullable()], {});
+  const pluginEntry = tuple<[string, PluginOptions]>([pluginSource, pluginOptions]);
 
   return union<PluginsSetting>(
-    [
-      array(string().notEmpty()),
-      object(union<PluginsSettingMapItem>([bool(), object().notNullable()], {})).notNullable(),
-    ],
+    [array(union([pluginSource, pluginEntry], '')), object(pluginOptions).notNullable()],
     {},
   );
 }

--- a/packages/config/src/predicates.ts
+++ b/packages/config/src/predicates.ts
@@ -14,15 +14,13 @@ export function createExtendsPredicate(preds: Predicates = predicates) {
 }
 
 export function createPluginsPredicate(preds: Predicates = predicates) {
-  const { array, bool, object, string, tuple, union } = preds;
-  const pluginSource = string().notEmpty();
-  const pluginOptions = union<PluginOptions>([bool(), object().notNullable()], {});
-  const pluginEntry = tuple<[string, PluginOptions]>([pluginSource, pluginOptions]);
+  const { array, bool, object, union } = preds;
+  const pluginOptions = union<PluginOptions>([bool(), object()], {});
+  // TODO: Bug in optimal, fix upstream
+  // const pluginSource = string();
+  // const pluginEntry = tuple<[string, PluginOptions]>([pluginSource, pluginOptions]);
 
-  return union<PluginsSetting>(
-    [array(union([pluginSource, pluginEntry], '')), object(pluginOptions).notNullable()],
-    {},
-  );
+  return union<PluginsSetting>([array(), object(pluginOptions).notNullable()], {});
 }
 
 export function createOverridesPredicate<T extends object>(

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -1,4 +1,4 @@
-import { ModuleName, PackageStructure, Path } from '@boost/common';
+import { PackageStructure, Path } from '@boost/common';
 
 export type ExtType = 'cjs' | 'js' | 'json' | 'json5' | 'mjs' | 'ts' | 'yaml' | 'yml';
 
@@ -59,12 +59,14 @@ export interface OverridesSettingItem<T> {
 
 export type OverridesSetting<T> = OverridesSettingItem<T>[];
 
-export type PluginsSettingMapItem = boolean | object;
+// PLUGINS
 
-export interface PluginsSettingMap {
-  [name: string]: PluginsSettingMapItem;
-}
+export type PluginOptions = boolean | object;
 
-export type PluginsSettingList = ModuleName[];
+export type PluginEntry = string | [string, PluginOptions];
+
+export type PluginsSettingMap = Record<string, PluginOptions>;
+
+export type PluginsSettingList = PluginEntry[];
 
 export type PluginsSetting = PluginsSettingList | PluginsSettingMap;

--- a/packages/config/tests/Processor.test.ts
+++ b/packages/config/tests/Processor.test.ts
@@ -219,8 +219,9 @@ describe('Processor', () => {
             defaults,
             [
               stubConfigFile({ plugins: { foo: true, qux: { on: true } } }),
-              stubConfigFile({ plugins: { bar: false } }),
+              stubConfigFile({ plugins: [['bar', false]] }),
               stubConfigFile({ plugins: { foo: { legacy: true }, baz: true, qux: { on: false } } }),
+              stubConfigFile({ plugins: ['oop'] }),
             ],
             blueprint,
           ),
@@ -231,6 +232,7 @@ describe('Processor', () => {
             bar: false,
             baz: true,
             qux: { on: false },
+            oop: true,
           },
         });
       });

--- a/packages/config/tests/__snapshots__/Processor.test.ts.snap
+++ b/packages/config/tests/__snapshots__/Processor.test.ts.snap
@@ -13,10 +13,10 @@ exports[`Processor processing extends setting errors for an empty string in an a
 exports[`Processor processing extends setting errors for an invalid value 1`] = `"Invalid field \\"extends\\" in .boost.js. Type must be one of: string, array<string>."`;
 
 exports[`Processor processing plugins setting errors for an invalid option value 1`] = `
-"Invalid field \\"plugins\\" in .boost.js. Type must be one of: array<string | [string, boolean | object]>, object<boolean | object>. Received object with the following invalidations:
+"Invalid field \\"plugins\\" in .boost.js. Type must be one of: array, object<boolean | object>. Received object with the following invalidations:
  - Invalid field \\"plugins.foo\\" in .boost.js. Type must be one of: boolean, object."
 `;
 
-exports[`Processor processing plugins setting errors for an invalid value 1`] = `"Invalid field \\"plugins\\" in .boost.js. Type must be one of: array<string | [string, boolean | object]>, object<boolean | object>."`;
+exports[`Processor processing plugins setting errors for an invalid value 1`] = `"Invalid field \\"plugins\\" in .boost.js. Type must be one of: array, object<boolean | object>."`;
 
 exports[`Processor processing validation validates each config 1`] = `"Invalid field \\"debug\\" in .boost.js. Must be a boolean."`;

--- a/packages/config/tests/__snapshots__/Processor.test.ts.snap
+++ b/packages/config/tests/__snapshots__/Processor.test.ts.snap
@@ -13,10 +13,10 @@ exports[`Processor processing extends setting errors for an empty string in an a
 exports[`Processor processing extends setting errors for an invalid value 1`] = `"Invalid field \\"extends\\" in .boost.js. Type must be one of: string, array<string>."`;
 
 exports[`Processor processing plugins setting errors for an invalid option value 1`] = `
-"Invalid field \\"plugins\\" in .boost.js. Type must be one of: array<string>, object<boolean | object>. Received object with the following invalidations:
+"Invalid field \\"plugins\\" in .boost.js. Type must be one of: array<string | [string, boolean | object]>, object<boolean | object>. Received object with the following invalidations:
  - Invalid field \\"plugins.foo\\" in .boost.js. Type must be one of: boolean, object."
 `;
 
-exports[`Processor processing plugins setting errors for an invalid value 1`] = `"Invalid field \\"plugins\\" in .boost.js. Type must be one of: array<string>, object<boolean | object>."`;
+exports[`Processor processing plugins setting errors for an invalid value 1`] = `"Invalid field \\"plugins\\" in .boost.js. Type must be one of: array<string | [string, boolean | object]>, object<boolean | object>."`;
 
 exports[`Processor processing validation validates each config 1`] = `"Invalid field \\"debug\\" in .boost.js. Must be a boolean."`;

--- a/packages/config/tests/helpers/mergePlugins.test.ts
+++ b/packages/config/tests/helpers/mergePlugins.test.ts
@@ -1,44 +1,94 @@
 import mergePlugins from '../../src/helpers/mergePlugins';
 
 describe('mergePlugins()', () => {
-  it('returns a merged object', () => {
-    expect(mergePlugins({ foo: true }, { bar: true })).toEqual({ foo: true, bar: true });
-  });
+  describe('objects', () => {
+    it('returns a merged object', () => {
+      expect(mergePlugins({ foo: true }, { bar: true })).toEqual({ foo: true, bar: true });
+    });
 
-  it('plugins of same name overwrite', () => {
-    expect(mergePlugins({ foo: true }, { foo: false })).toEqual({ foo: false });
-  });
+    it('plugins of same name overwrite', () => {
+      expect(mergePlugins({ foo: true }, { foo: false })).toEqual({ foo: false });
+    });
 
-  it('plugin options are merged', () => {
-    expect(mergePlugins({ foo: { debug: true }, bar: true }, { foo: { debug: false } })).toEqual({
-      foo: { debug: false },
-      bar: true,
+    it('plugin options are merged', () => {
+      expect(mergePlugins({ foo: { debug: true }, bar: true }, { foo: { debug: false } })).toEqual({
+        foo: { debug: false },
+        bar: true,
+      });
+    });
+
+    it('plugin options overwrite booleans', () => {
+      expect(mergePlugins({ foo: true }, { foo: { debug: false } })).toEqual({
+        foo: { debug: false },
+      });
+    });
+
+    it('undefined plugin options are skipped', () => {
+      expect(
+        mergePlugins(
+          { foo: true },
+          {
+            // @ts-expect-error
+            foo: undefined,
+          },
+        ),
+      ).toEqual({ foo: true });
     });
   });
 
-  it('plugin options overwrite booleans', () => {
-    expect(mergePlugins({ foo: true }, { foo: { debug: false } })).toEqual({
-      foo: { debug: false },
+  describe('arrays', () => {
+    it('returns a merged object', () => {
+      expect(mergePlugins(['foo'], ['bar'])).toEqual({ foo: true, bar: true });
     });
-  });
 
-  it('undefined plugin values are skipped', () => {
-    expect(
-      mergePlugins(
-        { foo: true },
-        {
+    it('plugins of same name are deduped', () => {
+      expect(mergePlugins(['foo'], ['foo'])).toEqual({ foo: true });
+    });
+
+    it('plugins of same name can be turned off using a tuple', () => {
+      expect(mergePlugins(['foo'], [['foo', false]])).toEqual({ foo: false });
+    });
+
+    it('plugin options are merged', () => {
+      expect(mergePlugins([['foo', { debug: true }], 'bar'], [['foo', { debug: false }]])).toEqual({
+        foo: { debug: false },
+        bar: true,
+      });
+    });
+
+    it('undefined plugin options are converted to a boolean true', () => {
+      expect(
+        mergePlugins(
+          ['foo'],
           // @ts-expect-error
-          foo: undefined,
-        },
-      ),
-    ).toEqual({ foo: true });
+          [['bar', undefined]],
+        ),
+      ).toEqual({ foo: true, bar: true });
+    });
   });
 
-  it('supports a list on the left', () => {
-    expect(mergePlugins(['foo'], { bar: {} })).toEqual({ foo: true, bar: {} });
-  });
+  describe('objects + arrays', () => {
+    it('supports a list on the left', () => {
+      expect(mergePlugins(['foo'], { bar: {} })).toEqual({ foo: true, bar: {} });
+    });
 
-  it('supports a list on the right', () => {
-    expect(mergePlugins({ foo: true, bar: false }, ['bar'])).toEqual({ foo: true, bar: true });
+    it('supports a list on the right', () => {
+      expect(mergePlugins({ foo: true, bar: false }, ['bar'])).toEqual({ foo: true, bar: true });
+    });
+
+    it('merges tuple and object options', () => {
+      expect(
+        mergePlugins({ foo: { debug: true }, bar: false, baz: true, qux: {} }, [
+          ['foo', { debug: false }],
+          'bar',
+          ['baz', false],
+        ]),
+      ).toEqual({
+        foo: { debug: false },
+        bar: true,
+        baz: false,
+        qux: {},
+      });
+    });
   });
 });

--- a/packages/plugin/src/Loader.ts
+++ b/packages/plugin/src/Loader.ts
@@ -1,21 +1,13 @@
 /* eslint-disable security/detect-non-literal-regexp */
 
 import path from 'path';
-import {
-  FilePath,
-  isFilePath,
-  isObject,
-  MODULE_NAME_PART,
-  ModuleName,
-  PathResolver,
-  requireModule,
-} from '@boost/common';
+import { isFilePath, isObject, MODULE_NAME_PART, PathResolver, requireModule } from '@boost/common';
 import { createDebugger, Debugger } from '@boost/debug';
 import { color } from '@boost/internal';
 import debug from './debug';
 import PluginError from './PluginError';
 import Registry from './Registry';
-import { Factory, Pluggable } from './types';
+import { Factory, Pluggable, Source } from './types';
 
 export default class Loader<Plugin extends Pluggable> {
   readonly debug: Debugger;
@@ -32,7 +24,7 @@ export default class Loader<Plugin extends Pluggable> {
    * based on a list of acceptable plugin module name patterns.
    */
   // eslint-disable-next-line complexity
-  createResolver(name: FilePath | ModuleName): PathResolver {
+  createResolver(name: Source): PathResolver {
     const resolver = new PathResolver();
     const { singularName: typeName, projectName } = this.registry;
     const moduleName = name.toLowerCase();
@@ -106,12 +98,13 @@ export default class Loader<Plugin extends Pluggable> {
   }
 
   /**
-   * Load a plugin by short name or fully qualified module name, with an optional options object.
+   * Load a plugin by short name or fully qualified module name, or file path,
+   * and with an optional options object.
    */
-  async load(name: FilePath | ModuleName, options: object = {}): Promise<Plugin> {
-    const { originalPath, resolvedPath } = this.createResolver(name).resolve();
+  async load(source: Source, options: object = {}): Promise<Plugin> {
+    const { originalPath, resolvedPath } = this.createResolver(source).resolve();
 
-    this.debug('Loading %s from %s', color.moduleName(name), color.filePath(resolvedPath));
+    this.debug('Loading %s from %s', color.moduleName(source), color.filePath(resolvedPath));
 
     const factory: Factory<Plugin> = requireModule(resolvedPath);
 

--- a/packages/plugin/src/Plugin.ts
+++ b/packages/plugin/src/Plugin.ts
@@ -4,7 +4,7 @@ import { Pluggable } from './types';
 export default abstract class Plugin<T = unknown, Options extends object = {}>
   extends Contract<Options>
   implements Pluggable<T> {
-  name = '';
+  readonly name = '';
 
   startup(tool: T) {}
 

--- a/packages/plugin/src/types.ts
+++ b/packages/plugin/src/types.ts
@@ -1,4 +1,10 @@
-import { ModuleName } from '@boost/common';
+import { FilePath, ModuleName } from '@boost/common';
+
+export type Source = FilePath | ModuleName;
+
+export type SourceOptions = boolean | object;
+
+export type SourceWithOptions = [Source, SourceOptions];
 
 export type Callback<T = unknown> = (value: T) => Promise<void> | void;
 
@@ -11,9 +17,7 @@ export interface Pluggable<T = any> {
   startup?: Callback<T>;
 }
 
-export interface Setting {
-  [name: string]: boolean | object;
-}
+export type Setting = Record<string, SourceOptions>;
 
 export type Factory<T extends Pluggable, O extends object = object> = (
   options: Partial<O>,
@@ -25,7 +29,7 @@ export interface RegisterOptions<T = unknown> {
 }
 
 export interface Registration<T extends Pluggable> extends RegisterOptions {
-  name: ModuleName;
+  name: Source;
   plugin: T;
 }
 

--- a/packages/plugin/src/types.ts
+++ b/packages/plugin/src/types.ts
@@ -29,7 +29,7 @@ export interface RegisterOptions<T = unknown> {
 }
 
 export interface Registration<T extends Pluggable> extends RegisterOptions {
-  name: Source;
+  name: ModuleName;
   plugin: T;
 }
 

--- a/packages/plugin/tests/__mocks__/Renderer.ts
+++ b/packages/plugin/tests/__mocks__/Renderer.ts
@@ -6,7 +6,7 @@ export interface Renderable extends Pluggable {
 }
 
 export class Renderer extends Plugin<unknown, { value: string }> implements Renderable {
-  name = '';
+  readonly name = '';
 
   priority = DEFAULT_PRIORITY;
 

--- a/website/docs/config.mdx
+++ b/website/docs/config.mdx
@@ -207,6 +207,9 @@ class Manager extends Configuration<ConfigFile> {
 A config file is a file that explicitly defines settings (key-value pairs) according to a defined
 structure.
 
+> Configuration files are designed to be serializable, so please use primitive, object, and array
+> values only. Try to avoid non-serializable values like class instances.
+
 ### File patterns
 
 Config files are grouped into either the root or branch category. Root config files are located in a

--- a/website/docs/config.mdx
+++ b/website/docs/config.mdx
@@ -184,8 +184,9 @@ used for common scenarios (these handlers power the default rules mentioned abov
   new list of file paths. This is useful if utilizing [config extending](#enable-extending).
 - `mergeObject` - Shallow merges previous and next objects into a new object using object spread.
 - `mergePlugins` - Merges previous and next plugin configurations into an object. Plugin configs can
-  either be a list of module names, or a map of module names to flags/options. This is useful if
-  utilizing the [plugin package](./plugin.mdx#configuration-files).
+  either be a list of sources, or list of sources with flags/options (tuples), or a map of sources
+  to flags/options. This is useful if utilizing the
+  [plugin package](./plugin.mdx#configuration-files).
 - `overwrite` - Overwrite the previous value with the next value.
 
 ```ts

--- a/website/docs/plugin.mdx
+++ b/website/docs/plugin.mdx
@@ -506,7 +506,7 @@ module, both long and short forms are supported.
 
 <Tabs
   groupId="package-manager"
-  defaultValue="yarn"
+  defaultValue="json"
   values={[
     { label: 'JSON', value: 'json' },
     { label: 'JS', value: 'js' },
@@ -514,7 +514,7 @@ module, both long and short forms are supported.
 >
   <TabItem value="json">
 
-```json
+```js
 {
   "renderers": [
     "foo", // @boost/renderer-foo, boost-renderer-foo
@@ -547,7 +547,7 @@ a tuple alongside the source. Plugins can also be disabled by passing a `false` 
 
 <Tabs
   groupId="package-manager"
-  defaultValue="yarn"
+  defaultValue="json"
   values={[
     { label: 'JSON', value: 'json' },
     { label: 'JS', value: 'js' },
@@ -555,7 +555,7 @@ a tuple alongside the source. Plugins can also be disabled by passing a `false` 
 >
   <TabItem value="json">
 
-```json
+```js
 {
   "renderers": [
     ["foo", { "async": true }],
@@ -584,12 +584,11 @@ module.exports = {
 </Tabs>
 
 The final format, which is quite advanced, is using an object that maps plugin sources to
-configurable options or flags (enable or disable the plugin). This format can be passed to
-[`loadMany()`](#loading-plugins).
+configurable options or flags (enable or disable the plugin).
 
 <Tabs
   groupId="package-manager"
-  defaultValue="yarn"
+  defaultValue="json"
   values={[
     { label: 'JSON', value: 'json' },
     { label: 'JS', value: 'js' },
@@ -597,7 +596,7 @@ configurable options or flags (enable or disable the plugin). This format can be
 >
   <TabItem value="json">
 
-```json
+```js
 {
   "renderers": {
     "foo": { "async": true }, // Enabled with options
@@ -624,6 +623,9 @@ module.exports = {
 
   </TabItem>
 </Tabs>
+
+> Configuration files are designed to be serializable, so passing class instances (Webpack/Rollup
+> style) is not supported. It's also not necessary with our factory pattern!
 
 ## Ecosystem
 

--- a/website/docs/plugin.mdx
+++ b/website/docs/plugin.mdx
@@ -498,50 +498,132 @@ await registry.loadMany(['foo', 'bar'], { tool });
 ### Configuration files
 
 The loader methods were built to support plugins defined in [configuration files](./config.mdx), as
-this is a common use case. Take the following examples that showcase JSON and JS based
-configurations.
+this is a common use case. Settings to configure plugins are designed with 3 different formats in
+mind, all of which can be used together, and will merge into a valid final result.
+
+The first is a simple array of plugin sources (module name or relative file path). When using a
+module, both long and short forms are supported.
+
+<Tabs
+  groupId="package-manager"
+  defaultValue="yarn"
+  values={[
+    { label: 'JSON', value: 'json' },
+    { label: 'JS', value: 'js' },
+  ]}
+>
+  <TabItem value="json">
+
+```json
+{
+  "renderers": [
+    "foo", // @boost/renderer-foo, boost-renderer-foo
+    "@boost/renderer-bar",
+    "@scope/boost-renderer-baz",
+    "../custom/renderer.js"
+  ]
+}
+```
+
+  </TabItem>
+  <TabItem value="js">
+
+```js
+module.exports = {
+  renderers: [
+    'foo', // @boost/renderer-foo, boost-renderer-foo
+    '@boost/renderer-bar',
+    '@scope/boost-renderer-baz',
+    '../custom/renderer.js',
+  ],
+};
+```
+
+  </TabItem>
+</Tabs>
+
+To expand upon the previous example, an individual plugin can be configured with options by passing
+a tuple alongside the source. Plugins can also be disabled by passing a `false` value.
+
+<Tabs
+  groupId="package-manager"
+  defaultValue="yarn"
+  values={[
+    { label: 'JSON', value: 'json' },
+    { label: 'JS', value: 'js' },
+  ]}
+>
+  <TabItem value="json">
+
+```json
+{
+  "renderers": [
+    ["foo", { "async": true }],
+    "@boost/renderer-bar",
+    ["@scope/boost-renderer-baz", false], // Disabled
+    "../custom/renderer.js"
+  ]
+}
+```
+
+  </TabItem>
+  <TabItem value="js">
+
+```js
+module.exports = {
+  renderers: [
+    ['foo', { async: true }],
+    '@boost/renderer-bar',
+    ['@scope/boost-renderer-baz', false], // Disabled
+    '../custom/renderer.js',
+  ],
+};
+```
+
+  </TabItem>
+</Tabs>
+
+The final format, which is quite advanced, is using an object that maps plugin sources to
+configurable options or flags (enable or disable the plugin). This format can be passed to
+[`loadMany()`](#loading-plugins).
+
+<Tabs
+  groupId="package-manager"
+  defaultValue="yarn"
+  values={[
+    { label: 'JSON', value: 'json' },
+    { label: 'JS', value: 'js' },
+  ]}
+>
+  <TabItem value="json">
 
 ```json
 {
   "renderers": {
-    "foo": { "async": true },
-    "@boost/renderer-bar": {},
-    "@scope/boost-renderer-baz": true
+    "foo": { "async": true }, // Enabled with options
+    "@boost/renderer-bar": {}, // Enabled with empty options
+    "@scope/boost-renderer-baz": false, // Disabled
+    "../custom/renderer.js": true // Enabled
   }
 }
 ```
 
+  </TabItem>
+  <TabItem value="js">
+
 ```js
 module.exports = {
   renderers: {
-    foo: { async: true },
-    '@boost/renderer-bar': {},
-    '@scope/boost-renderer-baz': true,
+    foo: { async: true }, // Enabled with options
+    '@boost/renderer-bar': {}, // Enabled with empty options
+    '@scope/boost-renderer-baz': false, // Disabled
+    '../custom/renderer.js': true, // Enabled
   },
 };
 ```
 
-And Webpack/Rollup styled configurations where plugins are instantiated manually.
-
-<!-- prettier-ignore -->
-```js
-import foo from 'boost-renderer-foo';
-import bar from '@boost/renderer-bar';
-import baz from '@scope/boost-renderer-baz';
-import qux from './renderers/qux';
-
-const barInstance = bar();
-barInstance.priority = 1;
-
-export default {
-  renderers: [
-    foo({ async: true }),
-    barInstance,
-    baz(),
-    qux(),
-  ],
-};
-```
+  </TabItem>
+</Tabs>
 
 ## Ecosystem
 


### PR DESCRIPTION
Config objects for plugins were supposed to be the solution, as they are very customizable. However, they become really annoying when there are a lot of plugins, and you only need to configure one. For example:

```
  drivers: {
    babel: true,
    eslint: true,
    jest: true,
    lerna: true,
    mocha: true,
    prettier: true,
    rollup: true,
    stylelint: true,
    typescript: {
      buildFolder: 'dts',
      declarationOnly: true,
    },
    webpack: true,
  },
```

This new approach supports tuples (Babel style), so that we can write this instead.

```
  drivers: [
    'babel',
    'eslint',
    'jest',
    'lerna',
    'mocha',
    'prettier',
    'rollup',
    'stylelint',
    [
      'typescript',
      {
        buildFolder: 'dts',
        declarationOnly: true,
      },
    ],
    'webpack',
  ],
```

They are converted to objects under the hood for accuracy.