### PR TITLE
new: Improve CLI startup time and performance.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "@types/wrap-ansi": "^3.0.0",
     "conventional-changelog-beemo": "^2.1.0",
     "fs-extra": "^9.1.0",
-    "lerna": "^4.0.0"
+    "lerna": "^4.0.0",
+    "time-require": "^0.1.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/cli/examples/bin.js
+++ b/packages/cli/examples/bin.js
@@ -1,3 +1,7 @@
+if (process.env.TIMING) {
+	require('time-require');
+}
+
 const { Program } = require('../lib');
 const BuildCommand = require('./commands/BuildCommand');
 const ConfirmCommand = require('./commands/ConfirmCommand');

--- a/packages/cli/examples/commands/ConfirmCommand.js
+++ b/packages/cli/examples/commands/ConfirmCommand.js
@@ -1,5 +1,6 @@
 const React = require('react');
-const { Command, Confirm } = require('../../lib');
+const { Command } = require('../../lib');
+const { Confirm } = require('../../lib/react');
 
 module.exports = class ConfirmCommand extends Command {
 	static description = 'Test `Confirm` component';

--- a/packages/cli/examples/commands/ExitCompCommand.js
+++ b/packages/cli/examples/commands/ExitCompCommand.js
@@ -1,6 +1,7 @@
 const React = require('react');
 const { Text } = require('ink');
-const { Command, useProgram } = require('../../lib');
+const { Command } = require('../../lib');
+const { useProgram } = require('../../lib/react');
 const sleep = require('../sleep');
 
 function Exit({ error }) {

--- a/packages/cli/examples/commands/InputCommand.js
+++ b/packages/cli/examples/commands/InputCommand.js
@@ -1,5 +1,6 @@
 const React = require('react');
-const { Command, Input, PasswordInput, HiddenInput } = require('../../lib');
+const { Command } = require('../../lib');
+const { Input, PasswordInput, HiddenInput } = require('../../lib/react');
 
 module.exports = class InputCommand extends Command {
 	static description = 'Test `Input` and related components';

--- a/packages/cli/examples/commands/LoggerCommand.js
+++ b/packages/cli/examples/commands/LoggerCommand.js
@@ -1,6 +1,7 @@
 const React = require('react');
 const { Box, Text } = require('ink');
-const { Command, ProgramContext } = require('../../lib');
+const { Command } = require('../../lib');
+const { ProgramContext } = require('../../lib/react');
 const random = require('../random');
 
 let timer;

--- a/packages/cli/examples/commands/MultiSelectCommand.js
+++ b/packages/cli/examples/commands/MultiSelectCommand.js
@@ -1,4 +1,4 @@
-const { MultiSelect } = require('../../lib');
+const { MultiSelect } = require('../../lib/react');
 const SelectCommand = require('./SelectCommand');
 
 module.exports = class MultiSelectCommand extends SelectCommand {

--- a/packages/cli/examples/commands/SelectCommand.js
+++ b/packages/cli/examples/commands/SelectCommand.js
@@ -1,5 +1,6 @@
 const React = require('react');
-const { Command, Select } = require('../../lib');
+const { Command } = require('../../lib');
+const { Select } = require('../../lib/react');
 
 module.exports = class SelectCommand extends Command {
 	static description = 'Test `Select` component';

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -19,6 +19,8 @@
   "files": [
     "dts/**/*.d.ts",
     "lib/**/*.{js,map}",
+    "react.d.ts",
+    "react.js",
     "res/",
     "src/**/*.{ts,tsx,json}",
     "test.d.ts",

--- a/packages/cli/react.d.ts
+++ b/packages/cli/react.d.ts
@@ -1,0 +1,1 @@
+export * from './dts/react';

--- a/packages/cli/react.js
+++ b/packages/cli/react.js
@@ -1,0 +1,1 @@
+module.exports = require('./lib/react.js');

--- a/packages/cli/src/Command.tsx
+++ b/packages/cli/src/Command.tsx
@@ -17,7 +17,6 @@ import { Blueprint, Predicates } from '@boost/common';
 import { LoggerFunction } from '@boost/log';
 import { CLIError } from './CLIError';
 import { CommandManager } from './CommandManager';
-import { Help } from './components/Help';
 import { INTERNAL_OPTIONS, INTERNAL_PARAMS, INTERNAL_PROGRAM } from './constants';
 import { Config } from './decorators/Config';
 import { mapCommandMetadata } from './helpers/mapCommandMetadata';
@@ -162,8 +161,9 @@ export abstract class Command<
 	/**
 	 * Create a React element based on the Help component.
 	 */
-	createHelp(): React.ReactElement {
+	async createHelp(): Promise<React.ReactElement> {
 		const metadata = this.getMetadata();
+		const { Help } = await import('./components/Help');
 
 		return (
 			<Help

--- a/packages/cli/src/Program.tsx
+++ b/packages/cli/src/Program.tsx
@@ -241,9 +241,7 @@ export class Program extends CommandManager<ProgramOptions> {
 			this.rendering = true;
 		}
 
-		// Import components on demand
 		const { Wrapper } = await import('./components/internal/Wrapper');
-
 		const { stdin, stdout, stderr } = this.streams;
 		const unpatchDebug = patchDebugModule();
 
@@ -345,7 +343,9 @@ export class Program extends CommandManager<ProgramOptions> {
 
 		if (this.standAlone) {
 			return (
-				<IndexHelp {...this.options}>{this.getCommand(this.standAlone)!.createHelp()}</IndexHelp>
+				<IndexHelp {...this.options}>
+					{await this.getCommand(this.standAlone)!.createHelp()}
+				</IndexHelp>
 			);
 		}
 

--- a/packages/cli/src/components/Help.tsx
+++ b/packages/cli/src/components/Help.tsx
@@ -6,16 +6,11 @@ import { OptionConfig, OptionConfigMap, ParamConfig, ParamConfigList } from '@bo
 import { toArray } from '@boost/common';
 import { stripAnsi } from '@boost/terminal';
 import { DELIMITER, SPACING_COL, SPACING_COL_WIDE, SPACING_ROW } from '../constants';
-import {
-	formatCommandCall,
-	formatDescription,
-	formatType,
-	getLongestWidth,
-	groupByCategory,
-} from '../helpers';
+import { formatDescription, formatType, getLongestWidth, groupByCategory } from '../helpers';
 import { msg } from '../translate';
 import { Categories, CommandConfig, CommandConfigMap } from '../types';
 import { Header } from './Header';
+import { HelpCommands } from './internal/HelpCommands';
 import { Style } from './Style';
 
 export interface HelpProps {
@@ -51,63 +46,6 @@ export class Help extends React.Component<HelpProps> {
 		}
 
 		return tags;
-	}
-
-	renderCommands(commands: CommandConfigMap) {
-		let pathWidth = 0;
-
-		const items = Object.entries(commands).map(([path, command]) => {
-			const pathCall = formatCommandCall(path, command);
-			const pathCallStripped = stripAnsi(pathCall);
-
-			if (pathCallStripped.length > pathWidth) {
-				pathWidth = pathCallStripped.length;
-			}
-
-			return {
-				...command,
-				name: path,
-				path,
-				pathCall,
-			};
-		});
-
-		const categorizedCommands = groupByCategory(items, this.props.categories ?? {});
-		const categoryCount = Object.keys(categorizedCommands).length;
-
-		return (
-			<>
-				<Header label={msg('cli:labelCommands')} />
-
-				{Object.entries(categorizedCommands).map(([key, category], index) => (
-					<Box key={key} flexDirection="column">
-						{!!category.name && categoryCount > 1 && (
-							<Box marginTop={index === 0 ? 0 : SPACING_ROW} paddingLeft={SPACING_COL}>
-								<Style bold type="none">
-									{category.name}
-								</Style>
-							</Box>
-						)}
-
-						{category.items.map((config) => {
-							const desc = formatDescription(config);
-
-							return (
-								<Box key={key + config.path} flexDirection="row" paddingLeft={SPACING_COL}>
-									<Box flexGrow={0} width={pathWidth + SPACING_COL_WIDE}>
-										<Text>{config.pathCall}</Text>
-									</Box>
-
-									<Box flexGrow={1}>
-										<Text wrap="wrap">{desc}</Text>
-									</Box>
-								</Box>
-							);
-						})}
-					</Box>
-				))}
-			</>
-		);
 	}
 
 	renderOptions(options: OptionConfigMap) {
@@ -247,7 +185,7 @@ export class Help extends React.Component<HelpProps> {
 
 	// eslint-disable-next-line complexity
 	override render() {
-		const { commands, options, header, params, config } = this.props;
+		const { categories, commands, options, header, params, config } = this.props;
 		const hasDesc = Boolean(config?.description);
 		const hasUsage = Boolean(config?.usage && config.usage.length > 0);
 		const hasParams = Boolean(params && params.length > 0);
@@ -268,7 +206,7 @@ export class Help extends React.Component<HelpProps> {
 
 				{hasParams && this.renderParams(params!)}
 
-				{hasCommands && this.renderCommands(commands!)}
+				{hasCommands && <HelpCommands categories={categories} commands={commands!} />}
 
 				{hasOptions && this.renderOptions(options!)}
 			</Box>

--- a/packages/cli/src/components/Help.tsx
+++ b/packages/cli/src/components/Help.tsx
@@ -1,17 +1,14 @@
-/* eslint-disable react/destructuring-assignment */
-
 import React from 'react';
 import { Box, Text } from 'ink';
-import { OptionConfig, OptionConfigMap, ParamConfig, ParamConfigList } from '@boost/args';
-import { toArray } from '@boost/common';
-import { stripAnsi } from '@boost/terminal';
-import { DELIMITER, SPACING_COL, SPACING_COL_WIDE, SPACING_ROW } from '../constants';
-import { formatDescription, formatType, getLongestWidth, groupByCategory } from '../helpers';
-import { msg } from '../translate';
+import { OptionConfigMap, ParamConfigList } from '@boost/args';
+import { SPACING_COL } from '../constants';
+import { formatDescription } from '../helpers';
 import { Categories, CommandConfig, CommandConfigMap } from '../types';
 import { Header } from './Header';
 import { HelpCommands } from './internal/HelpCommands';
-import { Style } from './Style';
+import { HelpOptions } from './internal/HelpOptions';
+import { HelpParams } from './internal/HelpParams';
+import { HelpUsage } from './internal/HelpUsage';
 
 export interface HelpProps {
 	categories?: Categories;
@@ -23,193 +20,39 @@ export interface HelpProps {
 	params?: ParamConfigList;
 }
 
-export class Help extends React.Component<HelpProps> {
-	gatherOptionTags(config: OptionConfig): string[] {
-		const tags: string[] = [];
+// eslint-disable-next-line complexity
+export function Help({
+	categories,
+	commands,
+	delimiter,
+	options,
+	header,
+	params,
+	config,
+}: HelpProps) {
+	const hasDesc = Boolean(config?.description);
+	const hasUsage = Boolean(config?.usage && config.usage.length > 0);
+	const hasParams = Boolean(params && params.length > 0);
+	const hasCommands = Boolean(commands && Object.keys(commands).length > 0);
+	const hasOptions = Boolean(options && Object.keys(options).length > 0);
 
-		if (config.count) {
-			tags.push(msg('cli:tagCount'));
-		}
+	return (
+		<Box flexDirection="column">
+			{(hasDesc || hasUsage) && header && <Header label={header} />}
 
-		if (config.multiple) {
-			tags.push(msg('cli:tagMultiple') + (config.arity ? `(${config.arity})` : ''));
-		}
+			{hasDesc && (
+				<Box paddingLeft={SPACING_COL}>
+					<Text>{formatDescription(config!)}</Text>
+				</Box>
+			)}
 
-		return tags;
-	}
+			{hasUsage && <HelpUsage delimiter={delimiter} usage={config?.usage} />}
 
-	gatherParamTags(config: ParamConfig): string[] {
-		const tags: string[] = [];
+			{hasParams && <HelpParams config={config} params={params!} />}
 
-		if (config.required) {
-			tags.push(msg('cli:tagRequired'));
-		}
+			{hasCommands && <HelpCommands categories={categories} commands={commands!} />}
 
-		return tags;
-	}
-
-	renderOptions(options: OptionConfigMap) {
-		let longWidth = 0;
-		let shortWidth = 0;
-
-		const items = Object.entries(options).map(([name, option]) => {
-			const shortLabel = option.short ? `-${option.short},` : '';
-			let longLabel = `--${option.default === true ? 'no-' : ''}${name}`;
-
-			if (option.type !== 'boolean') {
-				longLabel += ' ';
-				longLabel += formatType(option);
-			}
-
-			const longLabelStripped = stripAnsi(longLabel);
-			const shortLabelStripped = stripAnsi(shortLabel);
-
-			if (longLabelStripped.length > longWidth) {
-				longWidth = longLabelStripped.length;
-			}
-
-			if (shortLabelStripped.length > shortWidth) {
-				shortWidth = shortLabelStripped.length;
-			}
-
-			return {
-				...option,
-				longLabel,
-				name,
-				shortLabel,
-			};
-		});
-
-		const categorizedOptions = groupByCategory(items, this.props.categories ?? {});
-		const categoryCount = Object.keys(categorizedOptions).length;
-		const showShortColumn = shortWidth > 0;
-
-		return (
-			<>
-				<Header label={msg('cli:labelOptions')} />
-
-				{Object.entries(categorizedOptions).map(([key, category], index) => (
-					<Box key={key} flexDirection="column">
-						{!!category.name && categoryCount > 1 && (
-							<Box marginTop={index === 0 ? 0 : SPACING_ROW} paddingLeft={SPACING_COL}>
-								<Style bold type="none">
-									{category.name}
-								</Style>
-							</Box>
-						)}
-
-						{category.items.map((config) => (
-							<Box key={key + config.name} flexDirection="row" paddingLeft={SPACING_COL}>
-								{showShortColumn && (
-									<Box flexGrow={0} width={shortWidth + SPACING_COL}>
-										<Text>{config.shortLabel}</Text>
-									</Box>
-								)}
-
-								<Box flexGrow={0} width={longWidth + SPACING_COL_WIDE}>
-									<Text>{config.longLabel}</Text>
-								</Box>
-
-								<Box flexGrow={1}>
-									<Text wrap="wrap">
-										{formatDescription(config, this.gatherOptionTags(config))}
-									</Text>
-								</Box>
-							</Box>
-						))}
-					</Box>
-				))}
-			</>
-		);
-	}
-
-	renderParams(params: ParamConfigList) {
-		const labels = params.map((config, index) => `${config.label ?? index} ${formatType(config)}`);
-		const labelWidth = getLongestWidth(labels);
-		const allowVariadic = this.props.config?.allowVariadicParams;
-
-		return (
-			<>
-				<Header label={msg('cli:labelParams')} />
-
-				{params.map((config, index) => {
-					if (config.hidden) {
-						return null;
-					}
-
-					const desc = config ? formatDescription(config, this.gatherParamTags(config)) : '';
-
-					return (
-						<Box key={`${labels[index]}-${index}`} flexDirection="row" paddingLeft={SPACING_COL}>
-							<Box flexGrow={0} width={labelWidth + SPACING_COL_WIDE}>
-								<Text>{labels[index]}</Text>
-							</Box>
-
-							<Box flexGrow={1}>
-								<Text wrap="wrap">{desc}</Text>
-							</Box>
-						</Box>
-					);
-				})}
-
-				{allowVariadic && (
-					<Box paddingLeft={SPACING_COL}>
-						<Text>
-							{`…${typeof allowVariadic === 'string' ? allowVariadic : ''}`}{' '}
-							{formatType({
-								multiple: true,
-								type: 'string',
-							})}
-						</Text>
-					</Box>
-				)}
-			</>
-		);
-	}
-
-	renderUsage(usage: string[] | string = '') {
-		const { delimiter = DELIMITER } = this.props;
-
-		return (
-			<>
-				<Header label={msg('cli:labelUsage')} />
-
-				{toArray(usage).map((example) => (
-					<Box key={example} paddingLeft={SPACING_COL}>
-						<Text>{example.startsWith(delimiter) ? example : delimiter + example}</Text>
-					</Box>
-				))}
-			</>
-		);
-	}
-
-	// eslint-disable-next-line complexity
-	override render() {
-		const { categories, commands, options, header, params, config } = this.props;
-		const hasDesc = Boolean(config?.description);
-		const hasUsage = Boolean(config?.usage && config.usage.length > 0);
-		const hasParams = Boolean(params && params.length > 0);
-		const hasCommands = Boolean(commands && Object.keys(commands).length > 0);
-		const hasOptions = Boolean(options && Object.keys(options).length > 0);
-
-		return (
-			<Box flexDirection="column">
-				{(hasDesc || hasUsage) && header && <Header label={header} />}
-
-				{hasDesc && (
-					<Box paddingLeft={SPACING_COL}>
-						<Text>{formatDescription(config!)}</Text>
-					</Box>
-				)}
-
-				{hasUsage && this.renderUsage(config?.usage)}
-
-				{hasParams && this.renderParams(params!)}
-
-				{hasCommands && <HelpCommands categories={categories} commands={commands!} />}
-
-				{hasOptions && this.renderOptions(options!)}
-			</Box>
-		);
-	}
+			{hasOptions && <HelpOptions categories={categories} options={options!} />}
+		</Box>
+	);
 }

--- a/packages/cli/src/components/Help.tsx
+++ b/packages/cli/src/components/Help.tsx
@@ -1,30 +1,32 @@
-/* eslint-disable promise/prefer-await-to-then */
-
-import React, { Suspense } from 'react';
+import React from 'react';
 import { Box, Text } from 'ink';
 import { OptionConfigMap, ParamConfigList } from '@boost/args';
 import { SPACING_COL } from '../constants';
 import { formatDescription } from '../helpers';
 import { Categories, CommandConfig, CommandConfigMap } from '../types';
 import { Header } from './Header';
+import { HelpCommands } from './internal/HelpCommands';
+import { HelpOptions } from './internal/HelpOptions';
+import { HelpParams } from './internal/HelpParams';
+import { HelpUsage } from './internal/HelpUsage';
 
-function extractDefault<K extends string, P>(
-	key: K,
-): (result: Record<K, React.ComponentType<P>>) => { default: React.ComponentType<P> } {
-	return ({ [key]: component }) => ({ default: component });
-}
+// function extractDefault<K extends string, P>(
+// 	key: K,
+// ): (result: Record<K, React.ComponentType<P>>) => { default: React.ComponentType<P> } {
+// 	return ({ [key]: component }) => ({ default: component });
+// }
 
-const Commands = React.lazy(() =>
-	import('./internal/HelpCommands').then(extractDefault('HelpCommands')),
-);
+// const Commands = React.lazy(() =>
+// 	import('./internal/HelpCommands').then(extractDefault('HelpCommands')),
+// );
 
-const Options = React.lazy(() =>
-	import('./internal/HelpOptions').then(extractDefault('HelpOptions')),
-);
+// const Options = React.lazy(() =>
+// 	import('./internal/HelpOptions').then(extractDefault('HelpOptions')),
+// );
 
-const Params = React.lazy(() => import('./internal/HelpParams').then(extractDefault('HelpParams')));
+// const Params = React.lazy(() => import('./internal/HelpParams').then(extractDefault('HelpParams')));
 
-const Usage = React.lazy(() => import('./internal/HelpUsage').then(extractDefault('HelpUsage')));
+// const Usage = React.lazy(() => import('./internal/HelpUsage').then(extractDefault('HelpUsage')));
 
 export interface HelpProps {
 	categories?: Categories;
@@ -62,15 +64,13 @@ export function Help({
 				</Box>
 			)}
 
-			<Suspense fallback={null}>
-				{hasUsage && <Usage delimiter={delimiter} usage={config?.usage} />}
+			{hasUsage && <HelpUsage delimiter={delimiter} usage={config?.usage} />}
 
-				{hasParams && <Params config={config} params={params!} />}
+			{hasParams && <HelpParams config={config} params={params!} />}
 
-				{hasCommands && <Commands categories={categories} commands={commands!} />}
+			{hasCommands && <HelpCommands categories={categories} commands={commands!} />}
 
-				{hasOptions && <Options categories={categories} options={options!} />}
-			</Suspense>
+			{hasOptions && <HelpOptions categories={categories} options={options!} />}
 		</Box>
 	);
 }

--- a/packages/cli/src/components/internal/HelpCommands.tsx
+++ b/packages/cli/src/components/internal/HelpCommands.tsx
@@ -1,0 +1,79 @@
+import React, { useMemo, useRef } from 'react';
+import { Box, Text } from 'ink';
+import { stripAnsi } from '@boost/terminal';
+import { SPACING_COL, SPACING_COL_WIDE, SPACING_ROW } from '../../constants';
+import { formatCommandCall, formatDescription, groupByCategory } from '../../helpers';
+import { msg } from '../../translate';
+import { Categories, CommandConfigMap } from '../../types';
+import { Header } from '../Header';
+import { Style } from '../Style';
+
+export interface HelpCommandsProps {
+	categories?: Categories;
+	commands: CommandConfigMap;
+}
+
+export function HelpCommands({ categories, commands }: HelpCommandsProps) {
+	const pathWidth = useRef(0);
+
+	const items = useMemo(
+		() =>
+			Object.entries(commands).map(([path, command]) => {
+				const pathCall = formatCommandCall(path, command);
+				const pathCallStripped = stripAnsi(pathCall);
+
+				if (pathCallStripped.length > pathWidth.current) {
+					pathWidth.current = pathCallStripped.length;
+				}
+
+				return {
+					...command,
+					name: path,
+					path,
+					pathCall,
+				};
+			}),
+		[commands],
+	);
+
+	const categorizedCommands = useMemo(
+		() => groupByCategory(items, categories ?? {}),
+		[categories, items],
+	);
+
+	const categoryCount = Object.keys(categorizedCommands).length;
+
+	return (
+		<>
+			<Header label={msg('cli:labelCommands')} />
+
+			{Object.entries(categorizedCommands).map(([key, category], index) => (
+				<Box key={key} flexDirection="column">
+					{!!category.name && categoryCount > 1 && (
+						<Box marginTop={index === 0 ? 0 : SPACING_ROW} paddingLeft={SPACING_COL}>
+							<Style bold type="none">
+								{category.name}
+							</Style>
+						</Box>
+					)}
+
+					{category.items.map((config) => {
+						const desc = formatDescription(config);
+
+						return (
+							<Box key={key + config.path} flexDirection="row" paddingLeft={SPACING_COL}>
+								<Box flexGrow={0} width={pathWidth.current + SPACING_COL_WIDE}>
+									<Text>{config.pathCall}</Text>
+								</Box>
+
+								<Box flexGrow={1}>
+									<Text wrap="wrap">{desc}</Text>
+								</Box>
+							</Box>
+						);
+					})}
+				</Box>
+			))}
+		</>
+	);
+}

--- a/packages/cli/src/components/internal/HelpOptions.tsx
+++ b/packages/cli/src/components/internal/HelpOptions.tsx
@@ -1,0 +1,109 @@
+import React, { useMemo, useRef } from 'react';
+import { Box, Text } from 'ink';
+import { OptionConfig, OptionConfigMap } from '@boost/args';
+import { stripAnsi } from '@boost/terminal';
+import { SPACING_COL, SPACING_COL_WIDE, SPACING_ROW } from '../../constants';
+import { formatDescription, formatType, groupByCategory } from '../../helpers';
+import { msg } from '../../translate';
+import { Categories } from '../../types';
+import { Header } from '../Header';
+import { Style } from '../Style';
+
+function gatherOptionTags(config: OptionConfig): string[] {
+	const tags: string[] = [];
+
+	if (config.count) {
+		tags.push(msg('cli:tagCount'));
+	}
+
+	if (config.multiple) {
+		tags.push(msg('cli:tagMultiple') + (config.arity ? `(${config.arity})` : ''));
+	}
+
+	return tags;
+}
+
+export interface HelpOptionsProps {
+	categories?: Categories;
+	options: OptionConfigMap;
+}
+
+export function HelpOptions({ categories, options }: HelpOptionsProps) {
+	const longWidth = useRef(0);
+	const shortWidth = useRef(0);
+
+	const items = useMemo(
+		() =>
+			Object.entries(options).map(([name, option]) => {
+				const shortLabel = option.short ? `-${option.short},` : '';
+				let longLabel = `--${option.default === true ? 'no-' : ''}${name}`;
+
+				if (option.type !== 'boolean') {
+					longLabel += ' ';
+					longLabel += formatType(option);
+				}
+
+				const longLabelStripped = stripAnsi(longLabel);
+				const shortLabelStripped = stripAnsi(shortLabel);
+
+				if (longLabelStripped.length > longWidth.current) {
+					longWidth.current = longLabelStripped.length;
+				}
+
+				if (shortLabelStripped.length > shortWidth.current) {
+					shortWidth.current = shortLabelStripped.length;
+				}
+
+				return {
+					...option,
+					longLabel,
+					name,
+					shortLabel,
+				};
+			}),
+		[options],
+	);
+
+	const categorizedOptions = useMemo(
+		() => groupByCategory(items, categories ?? {}),
+		[categories, items],
+	);
+	const categoryCount = Object.keys(categorizedOptions).length;
+	const showShortColumn = shortWidth.current > 0;
+
+	return (
+		<>
+			<Header label={msg('cli:labelOptions')} />
+
+			{Object.entries(categorizedOptions).map(([key, category], index) => (
+				<Box key={key} flexDirection="column">
+					{!!category.name && categoryCount > 1 && (
+						<Box marginTop={index === 0 ? 0 : SPACING_ROW} paddingLeft={SPACING_COL}>
+							<Style bold type="none">
+								{category.name}
+							</Style>
+						</Box>
+					)}
+
+					{category.items.map((config) => (
+						<Box key={key + config.name} flexDirection="row" paddingLeft={SPACING_COL}>
+							{showShortColumn && (
+								<Box flexGrow={0} width={shortWidth.current + SPACING_COL}>
+									<Text>{config.shortLabel}</Text>
+								</Box>
+							)}
+
+							<Box flexGrow={0} width={longWidth.current + SPACING_COL_WIDE}>
+								<Text>{config.longLabel}</Text>
+							</Box>
+
+							<Box flexGrow={1}>
+								<Text wrap="wrap">{formatDescription(config, gatherOptionTags(config))}</Text>
+							</Box>
+						</Box>
+					))}
+				</Box>
+			))}
+		</>
+	);
+}

--- a/packages/cli/src/components/internal/HelpParams.tsx
+++ b/packages/cli/src/components/internal/HelpParams.tsx
@@ -1,0 +1,70 @@
+import React, { useMemo } from 'react';
+import { Box, Text } from 'ink';
+import { ParamConfig, ParamConfigList } from '@boost/args';
+import { SPACING_COL, SPACING_COL_WIDE } from '../../constants';
+import { formatDescription, formatType, getLongestWidth } from '../../helpers';
+import { msg } from '../../translate';
+import { CommandConfig } from '../../types';
+import { Header } from '../Header';
+
+function gatherParamTags(config: ParamConfig): string[] {
+	const tags: string[] = [];
+
+	if (config.required) {
+		tags.push(msg('cli:tagRequired'));
+	}
+
+	return tags;
+}
+
+export interface HelpParamsProps {
+	config?: CommandConfig;
+	params: ParamConfigList;
+}
+
+export function HelpParams({ config, params }: HelpParamsProps) {
+	const labels = useMemo(
+		() => params.map((p, index) => `${p.label ?? index} ${formatType(p)}`),
+		[params],
+	);
+	const labelWidth = getLongestWidth(labels);
+	const allowVariadic = config?.allowVariadicParams;
+
+	return (
+		<>
+			<Header label={msg('cli:labelParams')} />
+
+			{params.map((param, index) => {
+				if (param.hidden) {
+					return null;
+				}
+
+				const desc = param ? formatDescription(param, gatherParamTags(param)) : '';
+
+				return (
+					<Box key={`${labels[index]}-${index}`} flexDirection="row" paddingLeft={SPACING_COL}>
+						<Box flexGrow={0} width={labelWidth + SPACING_COL_WIDE}>
+							<Text>{labels[index]}</Text>
+						</Box>
+
+						<Box flexGrow={1}>
+							<Text wrap="wrap">{desc}</Text>
+						</Box>
+					</Box>
+				);
+			})}
+
+			{allowVariadic && (
+				<Box paddingLeft={SPACING_COL}>
+					<Text>
+						{`…${typeof allowVariadic === 'string' ? allowVariadic : ''}`}{' '}
+						{formatType({
+							multiple: true,
+							type: 'string',
+						})}
+					</Text>
+				</Box>
+			)}
+		</>
+	);
+}

--- a/packages/cli/src/components/internal/HelpUsage.tsx
+++ b/packages/cli/src/components/internal/HelpUsage.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+import { toArray } from '@boost/common';
+import { DELIMITER, SPACING_COL } from '../../constants';
+import { msg } from '../../translate';
+import { Header } from '../Header';
+
+export interface HelpUsageProps {
+	delimiter?: string;
+	usage?: string[] | string;
+}
+
+export function HelpUsage({ delimiter = DELIMITER, usage = '' }: HelpUsageProps) {
+	return (
+		<>
+			<Header label={msg('cli:labelUsage')} />
+
+			{toArray(usage).map((example) => (
+				<Box key={example} paddingLeft={SPACING_COL}>
+					<Text>{example.startsWith(delimiter) ? example : delimiter + example}</Text>
+				</Box>
+			))}
+		</>
+	);
+}

--- a/packages/cli/src/helpers/applyMarkdown.ts
+++ b/packages/cli/src/helpers/applyMarkdown.ts
@@ -5,9 +5,11 @@ export function applyMarkdown(text: string): string {
 		if (match.startsWith('~')) {
 			return style.strikethrough(body);
 		}
+
 		if (match.startsWith('**') || match.startsWith('__')) {
 			return style.bold(body);
 		}
+
 		if (match.startsWith('*') || match.startsWith('_')) {
 			return style.italic(body);
 		}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,12 +5,12 @@
 
 export * from './CLIError';
 export * from './Command';
-export * from './components';
 export * from './constants';
 export * from './decorators';
 export * from './helpers';
-export * from './hooks';
 export * from './middleware';
 export * from './Program';
-export * from './ProgramContext';
 export * from './types';
+
+// Remove in v3
+export * from './react';

--- a/packages/cli/src/react.ts
+++ b/packages/cli/src/react.ts
@@ -1,0 +1,3 @@
+export * from './components';
+export * from './hooks';
+export * from './ProgramContext';

--- a/packages/cli/src/test.ts
+++ b/packages/cli/src/test.ts
@@ -73,15 +73,24 @@ export async function renderComponent(
 	element: React.ReactElement,
 	stripped: boolean = false,
 ): Promise<string> {
-	const stdout = new MockWriteStream();
+	let output = '';
 
-	await render(element, {
-		debug: true,
-		experimental: true,
-		stdout: stdout as unknown as NodeJS.WriteStream,
-	});
+	try {
+		const { render: renderAsTest } = await import('ink-testing-library');
+		const { lastFrame } = await renderAsTest(element);
 
-	const output = stdout.get();
+		output = lastFrame() ?? '';
+	} catch {
+		const stdout = new MockWriteStream();
+
+		await render(element, {
+			debug: true,
+			experimental: true,
+			stdout: stdout as unknown as NodeJS.WriteStream,
+		});
+
+		output = stdout.get();
+	}
 
 	return stripped ? stripAnsi(output) : output;
 }

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -126,7 +126,7 @@ export interface CommandMetadata extends CommandStaticConfig {
 export type CommandMetadataMap = Record<string, CommandMetadata>;
 
 export interface Commandable<O extends object = any, P extends PrimitiveType[] = any[]> {
-	createHelp: () => React.ReactElement | string;
+	createHelp: () => Promise<React.ReactElement | string>;
 	getMetadata: () => CommandMetadata;
 	getParserOptions: () => ParserOptions<O, P>;
 	getPath: () => CommandPath;

--- a/packages/cli/tests/__snapshots__/Failure.test.tsx.snap
+++ b/packages/cli/tests/__snapshots__/Failure.test.tsx.snap
@@ -22,8 +22,7 @@ exports[`<Failure /> reduces command line by half when index appears off screen 
 
  Flags and short option groups may not use inline values.
 
- … wwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwww\\" --flag=123 -gSA \\"mmmmmmmmmmmm 
- …
+ … wwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwww\\" --flag=123 -gSA \\"mmmmmmmmmmmm …
                                                   └────────┘
 "
 `;

--- a/packages/cli/tests/__snapshots__/Help.test.tsx.snap
+++ b/packages/cli/tests/__snapshots__/Help.test.tsx.snap
@@ -24,8 +24,7 @@ exports[`<Help /> config renders description with additional params 1`] = `" I a
 
 exports[`<Help /> config renders description with markdown 1`] = `
 " This is the top level command description.
- All descriptions support markdown like [1mbold[22m, [1mstrong[22m, [3mitalics[23m, [3memphasis[23m, and
- [9mstrikethroughs[29m."
+ All descriptions support markdown like [1mbold[22m, [1mstrong[22m, [3mitalics[23m, [3memphasis[23m, and [9mstrikethroughs[29m."
 `;
 
 exports[`<Help /> options doesnt render empty options 1`] = `""`;
@@ -35,26 +34,22 @@ exports[`<Help /> options renders options (stripped) 1`] = `
  OPTIONS 
 
      --deprecatedFlag                        A deprecated flag. [deprecated]
-     --deprecatedStringWithALongName string  Deprecated string option with
-                                             custom label. [deprecated]
+     --deprecatedStringWithALongName string  Deprecated string option with custom label.
+                                             [deprecated]
      --flag                                  Standard boolean option.
      --num number                            Standard number option.
- -C, --numberCountable number                Number option that increments a
-                                             count for each occurence. (default:
-                                              10) [counter]
- -n, --numberFixedList number                A list of numbers to choose from.
-                                             (choices: 1, 2, 3, 4, 5, 6, 7, 8,
-                                             9, 10) [deprecated]
-     --numWithArity number[]                 A multiple number option that
-                                             requires an exact number of values.
-                                              [multiple(10)]
+ -C, --numberCountable number                Number option that increments a count for each
+                                             occurence. (default: 10) [counter]
+ -n, --numberFixedList number                A list of numbers to choose from. (choices: 1, 2, 3, 4,
+                                              5, 6, 7, 8, 9, 10) [deprecated]
+     --numWithArity number[]                 A multiple number option that requires an exact number
+                                             of values. [multiple(10)]
      --str string                            Standard string option.
- -s, --stringChoices string                  Choice list with strings. (choices:
-                                              \\"foo\\", \\"bar\\", \\"baz\\") (default:
-                                             \\"bar\\")
+ -s, --stringChoices string                  Choice list with strings. (choices: \\"foo\\", \\"bar\\",
+                                             \\"baz\\") (default: \\"bar\\")
  -S, --strList string[]                      String option list. [multiple]
- -t, --no-truthyBool                         Flag that is on by default, so name
-                                              should be negated. (default: true)"
+ -t, --no-truthyBool                         Flag that is on by default, so name should be negated.
+                                             (default: true)"
 `;
 
 exports[`<Help /> options renders options 1`] = `
@@ -62,26 +57,22 @@ exports[`<Help /> options renders options 1`] = `
 [1m[47m[30m OPTIONS [39m[49m[22m
 
      --deprecatedFlag                        A deprecated flag. [90m[deprecated][39m
-     --deprecatedStringWithALongName [90mstring[39m  Deprecated string option with
-                                             custom label. [90m[deprecated][39m
+     --deprecatedStringWithALongName [90mstring[39m  Deprecated string option with custom label.
+                                             [90m[deprecated][39m
      --flag                                  Standard boolean option.
      --num [90mnumber[39m                            Standard number option.
- -C, --numberCountable [90mnumber[39m                Number option that increments a
-                                             count for each occurence. (default:
-                                              10) [90m[counter][39m
- -n, --numberFixedList [90mnumber[39m                A list of numbers to choose from.
-                                             (choices: 1, 2, 3, 4, 5, 6, 7, 8,
-                                             9, 10) [90m[deprecated][39m
-     --numWithArity [90mnumber[][39m                 A multiple number option that
-                                             requires an exact number of values.
-                                              [90m[multiple(10)][39m
+ -C, --numberCountable [90mnumber[39m                Number option that increments a count for each
+                                             occurence. (default: 10) [90m[counter][39m
+ -n, --numberFixedList [90mnumber[39m                A list of numbers to choose from. (choices: 1, 2, 3, 4,
+                                              5, 6, 7, 8, 9, 10) [90m[deprecated][39m
+     --numWithArity [90mnumber[][39m                 A multiple number option that requires an exact number
+                                             of values. [90m[multiple(10)][39m
      --str [90mstring[39m                            Standard string option.
- -s, --stringChoices [90mstring[39m                  Choice list with strings. (choices:
-                                              \\"foo\\", \\"bar\\", \\"baz\\") (default:
-                                             \\"bar\\")
+ -s, --stringChoices [90mstring[39m                  Choice list with strings. (choices: \\"foo\\", \\"bar\\",
+                                             \\"baz\\") (default: \\"bar\\")
  -S, --strList [90mstring[][39m                      String option list. [90m[multiple][39m
- -t, --no-truthyBool                         Flag that is on by default, so name
-                                              should be negated. (default: true)"
+ -t, --no-truthyBool                         Flag that is on by default, so name should be negated.
+                                             (default: true)"
 `;
 
 exports[`<Help /> params doesnt render empty params 1`] = `""`;
@@ -128,26 +119,22 @@ exports[`<Help /> renders everything 1`] = `
 [1m[47m[30m OPTIONS [39m[49m[22m
 
      --deprecatedFlag                        A deprecated flag. [90m[deprecated][39m
-     --deprecatedStringWithALongName [90mstring[39m  Deprecated string option with
-                                             custom label. [90m[deprecated][39m
+     --deprecatedStringWithALongName [90mstring[39m  Deprecated string option with custom label.
+                                             [90m[deprecated][39m
      --flag                                  Standard boolean option.
      --num [90mnumber[39m                            Standard number option.
- -C, --numberCountable [90mnumber[39m                Number option that increments a
-                                             count for each occurence. (default:
-                                              10) [90m[counter][39m
- -n, --numberFixedList [90mnumber[39m                A list of numbers to choose from.
-                                             (choices: 1, 2, 3, 4, 5, 6, 7, 8,
-                                             9, 10) [90m[deprecated][39m
-     --numWithArity [90mnumber[][39m                 A multiple number option that
-                                             requires an exact number of values.
-                                              [90m[multiple(10)][39m
+ -C, --numberCountable [90mnumber[39m                Number option that increments a count for each
+                                             occurence. (default: 10) [90m[counter][39m
+ -n, --numberFixedList [90mnumber[39m                A list of numbers to choose from. (choices: 1, 2, 3, 4,
+                                              5, 6, 7, 8, 9, 10) [90m[deprecated][39m
+     --numWithArity [90mnumber[][39m                 A multiple number option that requires an exact number
+                                             of values. [90m[multiple(10)][39m
      --str [90mstring[39m                            Standard string option.
- -s, --stringChoices [90mstring[39m                  Choice list with strings. (choices:
-                                              \\"foo\\", \\"bar\\", \\"baz\\") (default:
-                                             \\"bar\\")
+ -s, --stringChoices [90mstring[39m                  Choice list with strings. (choices: \\"foo\\", \\"bar\\",
+                                             \\"baz\\") (default: \\"bar\\")
  -S, --strList [90mstring[][39m                      String option list. [90m[multiple][39m
- -t, --no-truthyBool                         Flag that is on by default, so name
-                                              should be negated. (default: true)"
+ -t, --no-truthyBool                         Flag that is on by default, so name should be negated.
+                                             (default: true)"
 `;
 
 exports[`<Help /> usage renders usage array 1`] = `

--- a/packages/cli/tests/__snapshots__/IndexHelp.test.tsx.snap
+++ b/packages/cli/tests/__snapshots__/IndexHelp.test.tsx.snap
@@ -53,26 +53,22 @@ Boost v1.2.3 [90mboost[39m
 [1m[47m[30m OPTIONS [39m[49m[22m
 
      --deprecatedFlag                        A deprecated flag. [90m[deprecated][39m
-     --deprecatedStringWithALongName [90mstring[39m  Deprecated string option with
-                                             custom label. [90m[deprecated][39m
+     --deprecatedStringWithALongName [90mstring[39m  Deprecated string option with custom label.
+                                             [90m[deprecated][39m
      --flag                                  Standard boolean option.
      --num [90mnumber[39m                            Standard number option.
- -C, --numberCountable [90mnumber[39m                Number option that increments a
-                                             count for each occurence. (default:
-                                              10) [90m[counter][39m
- -n, --numberFixedList [90mnumber[39m                A list of numbers to choose from.
-                                             (choices: 1, 2, 3, 4, 5, 6, 7, 8,
-                                             9, 10) [90m[deprecated][39m
-     --numWithArity [90mnumber[][39m                 A multiple number option that
-                                             requires an exact number of values.
-                                              [90m[multiple(10)][39m
+ -C, --numberCountable [90mnumber[39m                Number option that increments a count for each
+                                             occurence. (default: 10) [90m[counter][39m
+ -n, --numberFixedList [90mnumber[39m                A list of numbers to choose from. (choices: 1, 2, 3, 4,
+                                              5, 6, 7, 8, 9, 10) [90m[deprecated][39m
+     --numWithArity [90mnumber[][39m                 A multiple number option that requires an exact number
+                                             of values. [90m[multiple(10)][39m
      --str [90mstring[39m                            Standard string option.
- -s, --stringChoices [90mstring[39m                  Choice list with strings. (choices:
-                                              \\"foo\\", \\"bar\\", \\"baz\\") (default:
-                                             \\"bar\\")
+ -s, --stringChoices [90mstring[39m                  Choice list with strings. (choices: \\"foo\\", \\"bar\\",
+                                             \\"baz\\") (default: \\"bar\\")
  -S, --strList [90mstring[][39m                      String option list. [90m[multiple][39m
- -t, --no-truthyBool                         Flag that is on by default, so name
-                                              should be negated. (default: true)
+ -t, --no-truthyBool                         Flag that is on by default, so name should be negated.
+                                             (default: true)
 "
 `;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1910,11 +1910,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@boost/args@^2.3.2, @boost/args@workspace:packages/args":
+"@boost/args@^2.3.2, @boost/args@^2.3.3, @boost/args@workspace:packages/args":
   version: 0.0.0-use.local
   resolution: "@boost/args@workspace:packages/args"
   dependencies:
-    "@boost/internal": ^2.2.2
+    "@boost/internal": ^2.2.3
     levenary: ^1.1.1
   languageName: unknown
   linkType: soft
@@ -1923,13 +1923,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@boost/cli@workspace:packages/cli"
   dependencies:
-    "@boost/args": ^2.3.2
-    "@boost/common": ^2.7.2
-    "@boost/event": ^2.3.2
-    "@boost/internal": ^2.2.2
-    "@boost/log": ^2.2.5
-    "@boost/terminal": ^2.2.1
-    "@boost/translate": ^2.2.5
+    "@boost/args": ^2.3.3
+    "@boost/common": ^2.8.0
+    "@boost/event": ^2.3.3
+    "@boost/internal": ^2.2.3
+    "@boost/log": ^2.2.6
+    "@boost/terminal": ^2.2.2
+    "@boost/translate": ^2.2.6
     debug: ^4.3.2
     execa: ^5.1.1
     ink: ^3.0.8
@@ -1943,13 +1943,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@boost/common@^2.7.2, @boost/common@workspace:packages/common":
+"@boost/common@^2.7.2, @boost/common@^2.8.0, @boost/common@workspace:packages/common":
   version: 0.0.0-use.local
   resolution: "@boost/common@workspace:packages/common"
   dependencies:
-    "@boost/decorators": ^2.1.2
-    "@boost/internal": ^2.2.2
-    "@boost/test-utils": ^2.3.1
+    "@boost/decorators": ^2.1.3
+    "@boost/internal": ^2.2.3
+    "@boost/test-utils": ^2.3.2
     fast-glob: ^3.2.7
     json5: ^2.2.0
     optimal: ^4.3.0
@@ -1967,21 +1967,21 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@boost/config@workspace:packages/config"
   dependencies:
-    "@boost/common": ^2.7.2
-    "@boost/debug": ^2.2.5
-    "@boost/event": ^2.3.2
-    "@boost/internal": ^2.2.2
-    "@boost/test-utils": ^2.3.1
+    "@boost/common": ^2.8.0
+    "@boost/debug": ^2.2.6
+    "@boost/event": ^2.3.3
+    "@boost/internal": ^2.2.3
+    "@boost/test-utils": ^2.3.2
     minimatch: ^3.0.4
   languageName: unknown
   linkType: soft
 
-"@boost/debug@^2.2.5, @boost/debug@workspace:packages/debug":
+"@boost/debug@^2.2.5, @boost/debug@^2.2.6, @boost/debug@workspace:packages/debug":
   version: 0.0.0-use.local
   resolution: "@boost/debug@workspace:packages/debug"
   dependencies:
-    "@boost/common": ^2.7.2
-    "@boost/internal": ^2.2.2
+    "@boost/common": ^2.8.0
+    "@boost/internal": ^2.2.3
     "@types/debug": ^4.1.6
     debug: ^4.3.2
     execa: ^5.1.1
@@ -1989,21 +1989,21 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@boost/decorators@^2.1.2, @boost/decorators@workspace:packages/decorators":
+"@boost/decorators@^2.1.3, @boost/decorators@workspace:packages/decorators":
   version: 0.0.0-use.local
   resolution: "@boost/decorators@workspace:packages/decorators"
   languageName: unknown
   linkType: soft
 
-"@boost/event@^2.3.2, @boost/event@workspace:packages/event":
+"@boost/event@^2.3.2, @boost/event@^2.3.3, @boost/event@workspace:packages/event":
   version: 0.0.0-use.local
   resolution: "@boost/event@workspace:packages/event"
   dependencies:
-    "@boost/internal": ^2.2.2
+    "@boost/internal": ^2.2.3
   languageName: unknown
   linkType: soft
 
-"@boost/internal@^2.2.2, @boost/internal@workspace:packages/internal":
+"@boost/internal@^2.2.2, @boost/internal@^2.2.3, @boost/internal@workspace:packages/internal":
   version: 0.0.0-use.local
   resolution: "@boost/internal@workspace:packages/internal"
   dependencies:
@@ -2011,13 +2011,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@boost/log@^2.2.5, @boost/log@workspace:packages/log":
+"@boost/log@^2.2.5, @boost/log@^2.2.6, @boost/log@workspace:packages/log":
   version: 0.0.0-use.local
   resolution: "@boost/log@workspace:packages/log"
   dependencies:
-    "@boost/common": ^2.7.2
-    "@boost/internal": ^2.2.2
-    "@boost/translate": ^2.2.5
+    "@boost/common": ^2.8.0
+    "@boost/internal": ^2.2.3
+    "@boost/translate": ^2.2.6
     chalk: ^4.1.1
   languageName: unknown
   linkType: soft
@@ -2026,11 +2026,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@boost/pipeline@workspace:packages/pipeline"
   dependencies:
-    "@boost/common": ^2.7.2
-    "@boost/debug": ^2.2.5
-    "@boost/event": ^2.3.2
-    "@boost/internal": ^2.2.2
-    "@boost/translate": ^2.2.5
+    "@boost/common": ^2.8.0
+    "@boost/debug": ^2.2.6
+    "@boost/event": ^2.3.3
+    "@boost/internal": ^2.2.3
+    "@boost/translate": ^2.2.6
     execa: ^5.1.1
     lodash: ^4.17.21
     split: ^1.0.1
@@ -2041,18 +2041,18 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@boost/plugin@workspace:packages/plugin"
   dependencies:
-    "@boost/common": ^2.7.2
-    "@boost/debug": ^2.2.5
-    "@boost/event": ^2.3.2
-    "@boost/internal": ^2.2.2
-    "@boost/test-utils": ^2.3.1
+    "@boost/common": ^2.8.0
+    "@boost/debug": ^2.2.6
+    "@boost/event": ^2.3.3
+    "@boost/internal": ^2.2.3
+    "@boost/test-utils": ^2.3.2
     "@types/pluralize": ^0.0.29
     lodash: ^4.17.21
     pluralize: ^8.0.0
   languageName: unknown
   linkType: soft
 
-"@boost/terminal@^2.2.1, @boost/terminal@workspace:packages/terminal":
+"@boost/terminal@^2.2.1, @boost/terminal@^2.2.2, @boost/terminal@workspace:packages/terminal":
   version: 0.0.0-use.local
   resolution: "@boost/terminal@workspace:packages/terminal"
   dependencies:
@@ -2070,7 +2070,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@boost/test-utils@^2.3.1, @boost/test-utils@workspace:packages/test-utils":
+"@boost/test-utils@^2.3.2, @boost/test-utils@workspace:packages/test-utils":
   version: 0.0.0-use.local
   resolution: "@boost/test-utils@workspace:packages/test-utils"
   dependencies:
@@ -2120,12 +2120,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@boost/translate@^2.2.5, @boost/translate@workspace:packages/translate":
+"@boost/translate@^2.2.5, @boost/translate@^2.2.6, @boost/translate@workspace:packages/translate":
   version: 0.0.0-use.local
   resolution: "@boost/translate@workspace:packages/translate"
   dependencies:
-    "@boost/common": ^2.7.2
-    "@boost/internal": ^2.2.2
+    "@boost/common": ^2.8.0
+    "@boost/internal": ^2.2.3
     i18next: ^20.3.2
     os-locale: ^5.0.0
   languageName: unknown
@@ -5175,6 +5175,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ansi-styles@npm:~1.0.0":
+  version: 1.0.0
+  resolution: "ansi-styles@npm:1.0.0"
+  checksum: ae73b4e77dc35d47bf2c2eaf023c2a935a5bca01fe11eecaea307ee70ffb9d531db36e2cfc4cc0448e26cc40986b55a708a64c6f3e8589ec5d3cd44d2934b471
+  languageName: node
+  linkType: hard
+
 "anymatch@npm:^2.0.0":
   version: 2.0.0
   resolution: "anymatch@npm:2.0.0"
@@ -5903,6 +5910,7 @@ __metadata:
     conventional-changelog-beemo: ^2.1.0
     fs-extra: ^9.1.0
     lerna: ^4.0.0
+    time-require: ^0.1.2
   languageName: unknown
   linkType: soft
 
@@ -6233,6 +6241,17 @@ __metadata:
     escape-string-regexp: ^1.0.5
     supports-color: ^5.3.0
   checksum: 22c7b7b5bc761c882bb6516454a1a671923f1c53ff972860065aa0b28a195f230163c1d46ee88bcc7a03e5539177d896457d8bc727de7f244c6e87032743038e
+  languageName: node
+  linkType: hard
+
+"chalk@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "chalk@npm:0.4.0"
+  dependencies:
+    ansi-styles: ~1.0.0
+    has-color: ~0.1.0
+    strip-ansi: ~0.1.0
+  checksum: 77dac10ed002475631aa4dd420f06f4f27569b6d516fa130e8a7b02c9562af78af23209d2145afb07f423a2ca9dddb9d0658f75f6d559e3f47146e25866c6eeb
   languageName: node
   linkType: hard
 
@@ -7446,6 +7465,13 @@ __metadata:
     whatwg-mimetype: ^2.3.0
     whatwg-url: ^8.0.0
   checksum: 42239927c6a202e2d02b7f41c94ca53e3cea036898b97b8bf6120ed1b25e0dd11c48ec7aa5c84cf807c2cb9f3a637df9fb50f3ca25a52863186a4ac46254726b
+  languageName: node
+  linkType: hard
+
+"date-time@npm:^0.1.1":
+  version: 0.1.1
+  resolution: "date-time@npm:0.1.1"
+  checksum: 38225dceb1bc0530a3115e9a08b06c0592ed9421b4c22e2ae714e2a57437fc3e89d02cf093f63dca939a9b481936a67ac084e129c5cd0856888f2ca01a8621b5
   languageName: node
   linkType: hard
 
@@ -9892,6 +9918,13 @@ fsevents@^1.2.7:
   version: 1.0.1
   resolution: "has-bigints@npm:1.0.1"
   checksum: 1074b644f5f2c319fc31af00fe2f81b6e21e204bb46da70ff7b970fe65c56f504e697fe6b41823ba679bd4111840482a83327d3432b8d670a684da4087ed074b
+  languageName: node
+  linkType: hard
+
+"has-color@npm:~0.1.0":
+  version: 0.1.7
+  resolution: "has-color@npm:0.1.7"
+  checksum: 56775e5d514ac04c76191e284aff9c7bc7de6b964f6f3d8113458e86418cce05609b9da5e323dca48a24afead32e5cfd21ae9764264928bf3d1fb74847c9592e
   languageName: node
   linkType: hard
 
@@ -14434,6 +14467,13 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"parse-ms@npm:^0.1.0":
+  version: 0.1.2
+  resolution: "parse-ms@npm:0.1.2"
+  checksum: c96836facb1b082858cd0696763ca16c5abe16322068149d66f1f447bfa3cb27d40033cd377ac647e80e9ceec3069eb9b1f2c428afbed9b8c07fc063c211e9a2
+  languageName: node
+  linkType: hard
+
 "parse-ms@npm:^2.1.0":
   version: 2.1.0
   resolution: "parse-ms@npm:2.1.0"
@@ -15292,6 +15332,17 @@ fsevents@^1.2.7:
     ansi-styles: ^5.0.0
     react-is: ^17.0.1
   checksum: 29baf8d88a35c04ef81e310e3e239c6fe4f5b0827c9bd8f660df78e94632a9677bd113a64be78cc95c52945a4369b85828f32559cfd86c1b591aa3cc39d0798d
+  languageName: node
+  linkType: hard
+
+"pretty-ms@npm:^0.2.1":
+  version: 0.2.2
+  resolution: "pretty-ms@npm:0.2.2"
+  dependencies:
+    parse-ms: ^0.1.0
+  bin:
+    pretty-ms: cli.js
+  checksum: a2fee72a4f38611928d44b3ec54ba3c0069901ddcc107d21a22a9af536c530721f048654ba02080c22c21f7d6f41448a8c8b46ca6edc9bf1a21933bc43192fcc
   languageName: node
   linkType: hard
 
@@ -17619,6 +17670,15 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
+"strip-ansi@npm:~0.1.0":
+  version: 0.1.1
+  resolution: "strip-ansi@npm:0.1.1"
+  bin:
+    strip-ansi: cli.js
+  checksum: 4903d35c84023c925a4c417c2d7bdfe56abe45f974da43cac6fe660a098976dd32a2877a17b38687c341a40318a47ef61fac16f2640974bc131301eb6f14d911
+  languageName: node
+  linkType: hard
+
 "strip-bom-string@npm:^1.0.0":
   version: 1.0.0
   resolution: "strip-bom-string@npm:1.0.0"
@@ -18019,6 +18079,18 @@ resolve@^2.0.0-next.3:
   version: 1.1.0
   resolution: "thunky@npm:1.1.0"
   checksum: eceb856b6412ecd02c24731a2441698aa57622e03b0a4d6d1dea47d7b173aca54980fd2fba5b3a2e11ccec48373c46483f7f55a46717bfc07645395fa57267a6
+  languageName: node
+  linkType: hard
+
+"time-require@npm:^0.1.2":
+  version: 0.1.2
+  resolution: "time-require@npm:0.1.2"
+  dependencies:
+    chalk: ^0.4.0
+    date-time: ^0.1.1
+    pretty-ms: ^0.2.1
+    text-table: ^0.2.0
+  checksum: ec7112161fd59f280d0664ddc5eb48ac815466bc76824818172afa6efc852586b143f2223e3edfb72eb129da655a2c1267c831c937452092702d735e2f49b801
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
I've noticed that programs built on Boost take about 1.5 seconds on average before _actually_ outputting anything to the console... and also taking 3 seconds in total for something as simple as the help menu to render... This is bad...

I originally thought the problem was either a) the react/ink rendering cycle is slow, b) args parsing and middleware is slow, or c) running the program in general is slow. Turns out, it was none of these. React rendering is about 250ms at the highest, while args parsing is about 10ms, and running the program is dependent on rendering, so average at about 250ms also. So where is the performance bottleneck???

Turns out that simply`require`ing and evaluating all of the Boost files is the primary culprit. Just loading Boost libs take about 1.5 seconds, with the CLI package accounting for almost 1s worth. This is... unfortunate. To mitigate this problem, I am doing the following:

- Defer importing of React components until they actually used. This helps avoid the `require` load and the evaluation hit of the component (since components make up half of the package itself).
  - In v3, all of the React stuff will be moved behind `@boost/cli/react`.
  - Since this is now async, we can parallelize component rendering a bit.
- ~Utilized `React.lazy` and `Suspense` for rendering improvements.~ [Blocked by unit tests](https://github.com/vadimdemedes/ink-testing-library/issues/18)
- Split components down into function components, so that they can be memoized more effectively.
  
 In the end, I was able to improve performance by almost 50%! 

- CLI `require` load: 1.1s -> 750ms (600ms with React code moved to a separate file).
- Time to first output: 1.5s avg -> 1s avg
- Time to complete: 3s avg -> 1.7s avg