### PR TITLE
breaking: Update `PathResolver` and resolver functions to be async.

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -37,10 +37,12 @@
     "json5": "^2.2.0",
     "optimal": "^4.3.0",
     "pretty-ms": "^7.0.1",
+    "resolve": "^1.20.0",
     "yaml": "^1.10.2"
   },
   "devDependencies": {
-    "@boost/test-utils": "^3.0.0-alpha.0"
+    "@boost/test-utils": "^3.0.0-alpha.0",
+    "@types/resolve": "^1.20.1"
   },
   "peerDependencies": {
     "typescript": "^4.0.0"

--- a/packages/common/src/PathResolver.ts
+++ b/packages/common/src/PathResolver.ts
@@ -26,7 +26,7 @@ export class PathResolver {
 		this.lookups.push({
 			path: Path.resolve(filePath, cwd),
 			raw: Path.create(filePath),
-			type: LookupType.FILE_SYSTEM,
+			type: 'file-system',
 		});
 
 		return this;
@@ -41,7 +41,7 @@ export class PathResolver {
 		this.lookups.push({
 			path,
 			raw: path,
-			type: LookupType.NODE_MODULE,
+			type: 'node-module',
 		});
 
 		return this;
@@ -62,7 +62,7 @@ export class PathResolver {
 
 		this.lookups.some((lookup) => {
 			// Check that the file exists on the file system.
-			if (lookup.type === LookupType.FILE_SYSTEM) {
+			if (lookup.type === 'file-system') {
 				if (lookup.path.exists()) {
 					resolvedPath = lookup.path;
 					resolvedLookup = lookup;
@@ -72,7 +72,7 @@ export class PathResolver {
 
 				// Check that the module path exists using Node's module resolution.
 				// The `require.resolve` function will throw an error if not found.
-			} else if (lookup.type === LookupType.NODE_MODULE) {
+			} else if (lookup.type === 'node-module') {
 				try {
 					resolvedPath = this.resolver(lookup.path.path());
 					resolvedLookup = lookup;
@@ -86,7 +86,9 @@ export class PathResolver {
 
 		if (!resolvedPath || !resolvedLookup) {
 			throw new CommonError('PATH_RESOLVE_LOOKUPS', [
-				this.lookups.map((lookup) => `  - ${lookup.path} (${lookup.type})`).join('\n'),
+				this.lookups
+					.map((lookup) => `  - ${lookup.path} (${lookup.type.replace('-', ' ')})`)
+					.join('\n'),
 			]);
 		}
 

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -19,7 +19,13 @@ export interface Lookup {
 	type: LookupType;
 }
 
-export type ModuleResolver = (path: ModuleName) => FilePath;
+export interface ResolvedLookup {
+	originalPath: Path;
+	resolvedPath: Path;
+	type: LookupType;
+}
+
+export type ModuleResolver = (path: FilePath, startDir?: FilePath) => FilePath | Promise<FilePath>;
 
 // CLASSES
 

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -25,7 +25,7 @@ export interface ResolvedLookup {
 	type: LookupType;
 }
 
-export type ModuleResolver = (path: FilePath, startDir?: FilePath) => FilePath | Promise<FilePath>;
+export type ModuleResolver = (id: ModuleName, startDir?: FilePath) => FilePath | Promise<FilePath>;
 
 // CLASSES
 

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -11,10 +11,7 @@ export type FilePath = string;
 
 export type PortablePath = FilePath | Path;
 
-export enum LookupType {
-	FILE_SYSTEM = 'FILE_SYSTEM',
-	NODE_MODULE = 'NODE_MODULE',
-}
+export type LookupType = 'file-system' | 'node-module';
 
 export interface Lookup {
 	path: Path;

--- a/packages/common/tests/PathResolver.test.ts
+++ b/packages/common/tests/PathResolver.test.ts
@@ -1,3 +1,4 @@
+import resolve from 'resolve';
 import {
 	copyFixtureToNodeModule,
 	getFixturePath,
@@ -44,7 +45,7 @@ describe('PathResolver', () => {
 			'@boost/common',
 		]);
 
-		expect(await resolver.resolvePath()).toEqual(new Path(require.resolve('@boost/common')));
+		expect(await resolver.resolvePath()).toEqual(new Path(resolve.sync('@boost/common')));
 	});
 
 	it('can utilize a custom resolver', async () => {
@@ -113,7 +114,7 @@ describe('PathResolver', () => {
 
 			expect(await resolver.resolve()).toEqual({
 				originalPath: new Path('@boost/common'),
-				resolvedPath: new Path(require.resolve('@boost/common')),
+				resolvedPath: new Path(resolve.sync('@boost/common')),
 				type: 'node-module',
 			});
 		});

--- a/packages/common/tests/PathResolver.test.ts
+++ b/packages/common/tests/PathResolver.test.ts
@@ -13,7 +13,7 @@ describe('PathResolver', () => {
 		resolver = new PathResolver();
 	});
 
-	it('throws an error if no path is resolved', () => {
+	it('throws an error if no path is resolved', async () => {
 		resolver.lookupNodeModule('foo-bar');
 		resolver.lookupFilePath('foo/bar');
 		resolver.lookupFilePath('bar/baz');
@@ -26,12 +26,10 @@ describe('PathResolver', () => {
   - bar-baz (node module)
  [CMN:PATH_RESOLVE_LOOKUPS]`;
 
-		expect(() => {
-			resolver.resolvePath();
-		}).toThrow(new Error(error));
+		await expect(() => resolver.resolvePath()).rejects.toThrow(new Error(error));
 	});
 
-	it('returns first resolved node module or file path', () => {
+	it('returns first resolved node module or file path', async () => {
 		const cwd = getFixturePath('module-basic');
 
 		resolver.lookupFilePath('qux.js', cwd); // Doesnt exist
@@ -46,81 +44,92 @@ describe('PathResolver', () => {
 			'@boost/common',
 		]);
 
-		expect(resolver.resolvePath()).toEqual(new Path(require.resolve('@boost/common')));
+		expect(await resolver.resolvePath()).toEqual(new Path(require.resolve('@boost/common')));
+	});
+
+	it('can utilize a custom resolver', async () => {
+		resolver = new PathResolver(() => 'custom');
+		resolver.lookupNodeModule('unknown'); // Exists
+
+		expect(await resolver.resolve()).toEqual({
+			originalPath: new Path('unknown'),
+			resolvedPath: new Path('custom'),
+			type: 'node-module',
+		});
+	});
+
+	it('can utilize a custom async resolver', async () => {
+		resolver = new PathResolver(() => Promise.resolve('custom'));
+		resolver.lookupNodeModule('unknown'); // Exists
+
+		expect(await resolver.resolve()).toEqual({
+			originalPath: new Path('unknown'),
+			resolvedPath: new Path('custom'),
+			type: 'node-module',
+		});
 	});
 
 	describe('file system', () => {
-		it('returns first resolved path', () => {
+		it('returns first resolved path', async () => {
 			const cwd = getFixturePath('module-basic');
 
 			resolver.lookupFilePath('qux.js', cwd); // Doesnt exist
 			resolver.lookupFilePath('bar.js', cwd); // Exists
 			resolver.lookupFilePath('foo.js', cwd); // Exists
 
-			expect(resolver.resolve()).toEqual({
+			expect(await resolver.resolve()).toEqual({
 				originalPath: new Path('bar.js'),
 				resolvedPath: new Path(cwd, 'bar.js'),
 				type: 'file-system',
 			});
 		});
 
-		it('supports different cwds', () => {
+		it('supports different cwds', async () => {
 			const cwd = getFixturePath('module-basic');
 
 			resolver.lookupFilePath('qux.js', cwd); // Doesnt exist
 			resolver.lookupFilePath('bar.js'); // Doesnt exist at this cwd
 			resolver.lookupFilePath('foo.js', cwd); // Exists
 
-			expect(resolver.resolvePath()).toEqual(new Path(cwd, 'foo.js'));
+			expect(await resolver.resolvePath()).toEqual(new Path(cwd, 'foo.js'));
 		});
 
-		it('works with completely different parent folders and file extensions', () => {
+		it('works with completely different parent folders and file extensions', async () => {
 			const src = new Path(__dirname, '../src');
 
 			resolver.lookupFilePath('qux.js', getFixturePath('module-basic')); // Doesnt exist
 			resolver.lookupFilePath('bar.js', src); // Doesnt exist
 			resolver.lookupFilePath('toArray.ts', src.append('helpers')); // Exists
 
-			expect(resolver.resolvePath()).toEqual(new Path(src, 'helpers/toArray.ts'));
+			expect(await resolver.resolvePath()).toEqual(new Path(src, 'helpers/toArray.ts'));
 		});
 	});
 
 	describe('node modules', () => {
-		it('returns first resolved module', () => {
+		it('returns first resolved module', async () => {
 			resolver.lookupNodeModule('@boost/unknown'); // Doesnt exist
 			resolver.lookupNodeModule('@boost/common'); // Exists
 			resolver.lookupNodeModule('@boost/log'); // Exists
 
-			expect(resolver.resolve()).toEqual({
+			expect(await resolver.resolve()).toEqual({
 				originalPath: new Path('@boost/common'),
 				resolvedPath: new Path(require.resolve('@boost/common')),
 				type: 'node-module',
 			});
 		});
 
-		it('works with sub-paths', () => {
+		it('works with sub-paths', async () => {
 			const unmock = copyFixtureToNodeModule('module-basic', 'test-module-path-resolver');
 
 			resolver.lookupNodeModule('test-module-path-resolver/qux'); // Doesnt exist
 			resolver.lookupNodeModule('test-module-path-resolver/bar'); // Exists (without extension)
 			resolver.lookupNodeModule('test-module-path-resolver/foo.js'); // Exists
 
-			expect(resolver.resolvePath()).toEqual(
+			expect(await resolver.resolvePath()).toEqual(
 				new Path(getNodeModulePath('test-module-path-resolver', 'bar.js')),
 			);
 
 			unmock();
-		});
-
-		it('can utilize a custom resolver', () => {
-			resolver = new PathResolver(() => 'custom');
-			resolver.lookupNodeModule('unknown'); // Exists
-
-			expect(resolver.resolve()).toEqual({
-				originalPath: new Path('unknown'),
-				resolvedPath: new Path('custom'),
-				type: 'node-module',
-			});
 		});
 	});
 });

--- a/packages/common/tests/PathResolver.test.ts
+++ b/packages/common/tests/PathResolver.test.ts
@@ -4,7 +4,7 @@ import {
 	getNodeModulePath,
 	normalizePath,
 } from '@boost/test-utils';
-import { LookupType, Path, PathResolver } from '../src';
+import { Path, PathResolver } from '../src';
 
 describe('PathResolver', () => {
 	let resolver: PathResolver;
@@ -20,10 +20,10 @@ describe('PathResolver', () => {
 		resolver.lookupNodeModule('bar-baz');
 
 		const error = `Failed to resolve a path using the following lookups (in order):
-  - foo-bar (NODE_MODULE)
-  - ${normalizePath(process.cwd(), 'foo/bar')} (FILE_SYSTEM)
-  - ${normalizePath(process.cwd(), 'bar/baz')} (FILE_SYSTEM)
-  - bar-baz (NODE_MODULE)
+  - foo-bar (node module)
+  - ${normalizePath(process.cwd(), 'foo/bar')} (file system)
+  - ${normalizePath(process.cwd(), 'bar/baz')} (file system)
+  - bar-baz (node module)
  [CMN:PATH_RESOLVE_LOOKUPS]`;
 
 		expect(() => {
@@ -60,7 +60,7 @@ describe('PathResolver', () => {
 			expect(resolver.resolve()).toEqual({
 				originalPath: new Path('bar.js'),
 				resolvedPath: new Path(cwd, 'bar.js'),
-				type: LookupType.FILE_SYSTEM,
+				type: 'file-system',
 			});
 		});
 
@@ -94,7 +94,7 @@ describe('PathResolver', () => {
 			expect(resolver.resolve()).toEqual({
 				originalPath: new Path('@boost/common'),
 				resolvedPath: new Path(require.resolve('@boost/common')),
-				type: LookupType.NODE_MODULE,
+				type: 'node-module',
 			});
 		});
 
@@ -119,7 +119,7 @@ describe('PathResolver', () => {
 			expect(resolver.resolve()).toEqual({
 				originalPath: new Path('unknown'),
 				resolvedPath: new Path('custom'),
-				type: LookupType.NODE_MODULE,
+				type: 'node-module',
 			});
 		});
 	});

--- a/packages/config/src/ConfigFinder.ts
+++ b/packages/config/src/ConfigFinder.ts
@@ -203,7 +203,7 @@ export class ConfigFinder<T extends object> extends Finder<ConfigFile<T>, Config
 
 		this.debug('Extracting configs to extend from');
 
-		for await (const { config, path, source } of configs) {
+		for (const { config, path, source } of configs) {
 			const key = extendsSetting as keyof T;
 			const extendsFrom = config[key] as ExtendsSetting | undefined;
 

--- a/packages/config/src/ConfigFinder.ts
+++ b/packages/config/src/ConfigFinder.ts
@@ -7,6 +7,7 @@ import {
 	isModuleName,
 	PackageStructure,
 	Path,
+	PathResolver,
 	Predicates,
 	toArray,
 } from '@boost/common';
@@ -51,7 +52,7 @@ export class ConfigFinder<T extends object> extends Finder<ConfigFile<T>, Config
 			}).exact(),
 			name: string().required().camelCase(),
 			overridesSetting: string(),
-			resolver: func(require.resolve).notNullable(),
+			resolver: func(PathResolver.defaultResolver).notNullable(),
 		};
 	}
 
@@ -202,7 +203,7 @@ export class ConfigFinder<T extends object> extends Finder<ConfigFile<T>, Config
 
 		this.debug('Extracting configs to extend from');
 
-		configs.forEach(({ config, path, source }) => {
+		for await (const { config, path, source } of configs) {
 			const key = extendsSetting as keyof T;
 			const extendsFrom = config[key] as ExtendsSetting | undefined;
 
@@ -211,40 +212,48 @@ export class ConfigFinder<T extends object> extends Finder<ConfigFile<T>, Config
 			} else if (extendsFrom) {
 				throw new ConfigError('EXTENDS_ONLY_ROOT', [key]);
 			} else {
-				return;
+				// eslint-disable-next-line no-continue
+				continue;
 			}
 
-			toArray(extendsFrom).forEach((extendsPath) => {
-				// Node module
-				if (isModuleName(extendsPath)) {
-					const modulePath = new Path(
-						extendsPath,
-						createFileName(name, 'js', { envSuffix: 'preset' }),
-					);
+			const extendedPaths = await Promise.all(
+				toArray(extendsFrom).map(async (extendsPath) => {
+					// Node module
+					if (isModuleName(extendsPath)) {
+						const modulePath = new Path(
+							extendsPath,
+							createFileName(name, 'js', { envSuffix: 'preset' }),
+						);
 
-					this.debug('Extending config from node module: %s', color.moduleName(modulePath.path()));
+						this.debug(
+							'Extending config from node module: %s',
+							color.moduleName(modulePath.path()),
+						);
 
-					extendsPaths.push(new Path(resolver(modulePath.path())));
-
-					// File path
-				} else if (isFilePath(extendsPath)) {
-					let filePath = new Path(extendsPath);
-
-					// Relative to the config file its defined in
-					if (!filePath.isAbsolute()) {
-						filePath = path.parent().append(extendsPath);
+						return new Path(await resolver(modulePath.path()));
 					}
 
-					this.debug('Extending config from file path: %s', color.filePath(filePath.path()));
+					// File path
+					if (isFilePath(extendsPath)) {
+						let filePath = new Path(extendsPath);
 
-					extendsPaths.push(filePath);
+						// Relative to the config file its defined in
+						if (!filePath.isAbsolute()) {
+							filePath = path.parent().append(extendsPath);
+						}
+
+						this.debug('Extending config from file path: %s', color.filePath(filePath.path()));
+
+						return filePath;
+					}
 
 					// Unknown
-				} else {
 					throw new ConfigError('EXTENDS_UNKNOWN_PATH', [extendsPath]);
-				}
-			});
-		});
+				}),
+			);
+
+			extendsPaths.push(...extendedPaths);
+		}
 
 		return Promise.all(extendsPaths.map((path) => this.loadConfig(path, 'extended')));
 	}

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -48,7 +48,7 @@ export interface ConfigFinderOptions<T> {
 	name: string;
 	/** Name of the setting in which "config overriding" is enabled. */
 	overridesSetting?: string;
-	/** Custom module resolver instead of `require.resolve`. */
+	/** Custom module resolver. */
 	resolver?: ModuleResolver;
 }
 

--- a/packages/config/tsconfig.json
+++ b/packages/config/tsconfig.json
@@ -29,6 +29,9 @@
       "path": "../internal"
     },
     {
+      "path": "../module"
+    },
+    {
       "path": "../test-utils"
     }
   ]

--- a/packages/plugin/src/Loader.ts
+++ b/packages/plugin/src/Loader.ts
@@ -101,7 +101,7 @@ export class Loader<Plugin extends Pluggable> {
 	 * and with an optional options object.
 	 */
 	async load(source: Source, options: object = {}): Promise<Plugin> {
-		const { originalPath, resolvedPath } = this.createResolver(source).resolve();
+		const { originalPath, resolvedPath } = await this.createResolver(source).resolve();
 
 		this.debug('Loading %s from %s', color.moduleName(source), color.filePath(resolvedPath));
 

--- a/packages/plugin/src/Registry.ts
+++ b/packages/plugin/src/Registry.ts
@@ -8,6 +8,7 @@ import {
 	MODULE_NAME_PATTERN,
 	ModuleName,
 	ModuleResolver,
+	PathResolver,
 	Predicates,
 } from '@boost/common';
 import { createDebugger, Debugger } from '@boost/debug';
@@ -95,7 +96,7 @@ export class Registry<Plugin extends Pluggable, Tool = unknown> extends Contract
 			afterStartup: func<Callback>(),
 			beforeShutdown: func<Callback>(),
 			beforeStartup: func<Callback>(),
-			resolver: func<ModuleResolver>(require.resolve).notNullable(),
+			resolver: func<ModuleResolver>(PathResolver.defaultResolver).notNullable(),
 			validate: func<Callback>().notNullable().required(),
 		};
 	}

--- a/packages/plugin/src/types.ts
+++ b/packages/plugin/src/types.ts
@@ -50,7 +50,7 @@ export interface RegistryOptions<T extends Pluggable> {
 	beforeShutdown?: Callback<T> | null;
 	/** Callback fired before a plugin's `startup` life cycle is executed. */
 	beforeStartup?: Callback<T> | null;
-	/** Custom module resolver instead of `require.resolve`. */
+	/** Custom module resolver. */
 	resolver?: ModuleResolver;
 	/** Validate the shape of the plugin being registered. */
 	validate: Callback<T>;

--- a/packages/plugin/tests/Registry.test.ts
+++ b/packages/plugin/tests/Registry.test.ts
@@ -201,17 +201,17 @@ describe('Registry', () => {
 					priority: DEFAULT_PRIORITY,
 				},
 				{
-					name: 'boost-test-renderer-foo',
-					plugin: expect.any(Object),
-					priority: DEFAULT_PRIORITY,
-				},
-				{
 					name: '@boost-test/renderer-bar',
 					plugin: expect.any(Object),
 					priority: DEFAULT_PRIORITY,
 				},
 				{
 					name: '@test/boost-test-renderer-baz',
+					plugin: expect.any(Object),
+					priority: DEFAULT_PRIORITY,
+				},
+				{
+					name: 'boost-test-renderer-foo',
 					plugin: expect.any(Object),
 					priority: DEFAULT_PRIORITY,
 				},
@@ -220,22 +220,22 @@ describe('Registry', () => {
 
 		it('loads plugins using a tuple with options', async () => {
 			fixtures.push(
-				copyFixtureToNodeModule('plugin-renderer-object', 'boost-test-renderer-foo'),
-				copyFixtureToNodeModule('plugin-renderer-object', '@boost-test/renderer-bar'),
-				copyFixtureToNodeModule('plugin-renderer-object', '@test/boost-test-renderer-baz'),
+				copyFixtureToNodeModule('plugin-renderer-object', 'boost-test-renderer-foo2'),
+				copyFixtureToNodeModule('plugin-renderer-object', '@boost-test/renderer-bar2'),
+				copyFixtureToNodeModule('plugin-renderer-object', '@test/boost-test-renderer-baz2'),
 			);
 
 			await registry.loadMany(
 				[
 					// Short names
-					['foo', { value: 'foo' }],
-					'bar',
+					['foo2', { value: 'foo2' }],
+					'bar2',
 					// Full names
-					'boost-test-renderer-foo',
-					['@boost-test/renderer-bar', { value: 'bar' }],
+					'boost-test-renderer-foo2',
+					['@boost-test/renderer-bar2', { value: 'bar2' }],
 					// Full name with custom scope
-					'@test/boost-test-renderer-baz',
-					['@test/baz', false],
+					'@test/boost-test-renderer-baz2',
+					['@test/baz2', false],
 				],
 				{ tool },
 			);
@@ -243,32 +243,32 @@ describe('Registry', () => {
 			// @ts-expect-error Allow access
 			expect(registry.plugins).toEqual([
 				{
-					name: 'boost-test-renderer-foo',
+					name: 'boost-test-renderer-foo2',
+					plugin: expect.any(Object),
+					priority: DEFAULT_PRIORITY,
+				},
+				{
+					name: '@boost-test/renderer-bar2',
+					plugin: expect.any(Object),
+					priority: DEFAULT_PRIORITY,
+				},
+				{
+					name: '@boost-test/renderer-bar2',
 					plugin: expect.objectContaining({
-						options: { value: 'foo' },
+						options: { value: 'bar2' },
 					}),
 					priority: DEFAULT_PRIORITY,
 				},
 				{
-					name: '@boost-test/renderer-bar',
+					name: '@test/boost-test-renderer-baz2',
 					plugin: expect.any(Object),
 					priority: DEFAULT_PRIORITY,
 				},
 				{
-					name: 'boost-test-renderer-foo',
-					plugin: expect.any(Object),
-					priority: DEFAULT_PRIORITY,
-				},
-				{
-					name: '@boost-test/renderer-bar',
+					name: 'boost-test-renderer-foo2',
 					plugin: expect.objectContaining({
-						options: { value: 'bar' },
+						options: { value: 'foo2' },
 					}),
-					priority: DEFAULT_PRIORITY,
-				},
-				{
-					name: '@test/boost-test-renderer-baz',
-					plugin: expect.any(Object),
 					priority: DEFAULT_PRIORITY,
 				},
 			]);
@@ -276,19 +276,19 @@ describe('Registry', () => {
 
 		it('loads plugins using an object with options', async () => {
 			fixtures.push(
-				copyFixtureToNodeModule('plugin-renderer-object', 'boost-test-renderer-foo'),
-				copyFixtureToNodeModule('plugin-renderer-object', '@boost-test/renderer-bar'),
-				copyFixtureToNodeModule('plugin-renderer-object', '@test/boost-test-renderer-baz'),
+				copyFixtureToNodeModule('plugin-renderer-object', 'boost-test-renderer-foo3'),
+				copyFixtureToNodeModule('plugin-renderer-object', '@boost-test/renderer-bar3'),
+				copyFixtureToNodeModule('plugin-renderer-object', '@test/boost-test-renderer-baz3'),
 			);
 
 			await registry.loadMany(
 				{
 					// Short names
-					foo: { value: 'foo' },
+					foo3: { value: 'foo3' },
 					// Full names
-					'@boost-test/renderer-bar': { value: 'bar' },
+					'@boost-test/renderer-bar3': { value: 'bar3' },
 					// Full name enabled
-					'@test/baz': true,
+					'@test/baz3': true,
 					// Short name disabled
 					qux: false,
 				},
@@ -298,23 +298,23 @@ describe('Registry', () => {
 			// @ts-expect-error Allow access
 			expect(registry.plugins).toEqual([
 				{
-					name: 'boost-test-renderer-foo',
+					name: '@boost-test/renderer-bar3',
 					plugin: expect.objectContaining({
-						options: { value: 'foo' },
+						options: { value: 'bar3' },
 					}),
 					priority: 100,
 				},
 				{
-					name: '@boost-test/renderer-bar',
-					plugin: expect.objectContaining({
-						options: { value: 'bar' },
-					}),
-					priority: 100,
-				},
-				{
-					name: '@test/boost-test-renderer-baz',
+					name: '@test/boost-test-renderer-baz3',
 					plugin: expect.objectContaining({
 						options: {},
+					}),
+					priority: 100,
+				},
+				{
+					name: 'boost-test-renderer-foo3',
+					plugin: expect.objectContaining({
+						options: { value: 'foo3' },
 					}),
 					priority: 100,
 				},

--- a/packages/plugin/tests/Registry.test.ts
+++ b/packages/plugin/tests/Registry.test.ts
@@ -1,6 +1,10 @@
 import { copyFixtureToNodeModule } from '@boost/test-utils';
-import { DEFAULT_PRIORITY, Registry } from '../src';
+import { DEFAULT_PRIORITY, Registration, Registry } from '../src';
 import { createRendererRegistry, Renderable, Renderer } from './__fixtures__/Renderer';
+
+function sortByName(a: Registration<Renderable>, b: Registration<Renderable>) {
+	return a.name.localeCompare(b.name);
+}
 
 describe('Registry', () => {
 	const tool = { name: 'Tool', tool: true };
@@ -189,12 +193,9 @@ describe('Registry', () => {
 			);
 
 			// @ts-expect-error Allow access
-			expect(registry.plugins).toEqual([
-				{
-					name: 'boost-test-renderer-foo',
-					plugin: expect.any(Object),
-					priority: DEFAULT_PRIORITY,
-				},
+			const plugins = registry.plugins.sort(sortByName);
+
+			expect(plugins).toEqual([
 				{
 					name: '@boost-test/renderer-bar',
 					plugin: expect.any(Object),
@@ -207,6 +208,11 @@ describe('Registry', () => {
 				},
 				{
 					name: '@test/boost-test-renderer-baz',
+					plugin: expect.any(Object),
+					priority: DEFAULT_PRIORITY,
+				},
+				{
+					name: 'boost-test-renderer-foo',
 					plugin: expect.any(Object),
 					priority: DEFAULT_PRIORITY,
 				},
@@ -241,12 +247,9 @@ describe('Registry', () => {
 			);
 
 			// @ts-expect-error Allow access
-			expect(registry.plugins).toEqual([
-				{
-					name: 'boost-test-renderer-foo2',
-					plugin: expect.any(Object),
-					priority: DEFAULT_PRIORITY,
-				},
+			const plugins = registry.plugins.sort(sortByName);
+
+			expect(plugins).toEqual([
 				{
 					name: '@boost-test/renderer-bar2',
 					plugin: expect.any(Object),
@@ -261,6 +264,11 @@ describe('Registry', () => {
 				},
 				{
 					name: '@test/boost-test-renderer-baz2',
+					plugin: expect.any(Object),
+					priority: DEFAULT_PRIORITY,
+				},
+				{
+					name: 'boost-test-renderer-foo2',
 					plugin: expect.any(Object),
 					priority: DEFAULT_PRIORITY,
 				},
@@ -296,7 +304,9 @@ describe('Registry', () => {
 			);
 
 			// @ts-expect-error Allow access
-			expect(registry.plugins).toEqual([
+			const plugins = registry.plugins.sort(sortByName);
+
+			expect(plugins).toEqual([
 				{
 					name: '@boost-test/renderer-bar3',
 					plugin: expect.objectContaining({
@@ -338,7 +348,17 @@ describe('Registry', () => {
 			);
 
 			// @ts-expect-error Allow access
-			expect(registry.plugins).toEqual([
+			const plugins = registry.plugins.sort(sortByName);
+
+			expect(plugins).toEqual([
+				{
+					name: '@boost-test/renderer-bar',
+					plugin: expect.objectContaining({
+						options: { value: 'bar' },
+						render,
+					}),
+					priority: DEFAULT_PRIORITY,
+				},
 				{
 					name: '@test/boost-test-renderer-baz',
 					plugin: expect.objectContaining({
@@ -350,14 +370,6 @@ describe('Registry', () => {
 				{
 					name: 'boost-test-renderer-foo',
 					plugin: expect.objectContaining({ render }),
-					priority: DEFAULT_PRIORITY,
-				},
-				{
-					name: '@boost-test/renderer-bar',
-					plugin: expect.objectContaining({
-						options: { value: 'bar' },
-						render,
-					}),
 					priority: DEFAULT_PRIORITY,
 				},
 			]);
@@ -375,7 +387,14 @@ describe('Registry', () => {
 			await registry.loadMany([foo, bar, baz], { tool });
 
 			// @ts-expect-error Allow access
-			expect(registry.plugins).toEqual([
+			const plugins = registry.plugins.sort(sortByName);
+
+			expect(plugins).toEqual([
+				{
+					name: '@boost-test/renderer-bar',
+					plugin: bar,
+					priority: DEFAULT_PRIORITY,
+				},
 				{
 					name: '@test/boost-test-renderer-baz',
 					plugin: baz,
@@ -384,11 +403,6 @@ describe('Registry', () => {
 				{
 					name: 'boost-test-renderer-foo',
 					plugin: foo,
-					priority: DEFAULT_PRIORITY,
-				},
-				{
-					name: '@boost-test/renderer-bar',
-					plugin: bar,
 					priority: DEFAULT_PRIORITY,
 				},
 			]);

--- a/packages/plugin/tsconfig.json
+++ b/packages/plugin/tsconfig.json
@@ -29,6 +29,9 @@
       "path": "../internal"
     },
     {
+      "path": "../module"
+    },
+    {
       "path": "../test-utils"
     }
   ]

--- a/website/docs/common.mdx
+++ b/website/docs/common.mdx
@@ -251,6 +251,9 @@ demonstrate below. Import and instantiate the class to begin.
 import { PathResolver } from '@boost/common';
 
 const resolver = new PathResolver();
+
+// With a custom module resolver (can be async!)
+const resolver = new PathResolver(customResolver);
 ```
 
 To add a file system lookup, use the
@@ -286,11 +289,12 @@ resolver.lookupNodeModule('tool-config-module/lib/configs/tool.js');
 Once all the lookup paths have been defined, the
 [`PathResolver#resolve()`](/api/common/class/PathResolver#resolve) method will iterate through them
 in order until one is found. If a file system path, `fs.existsSync()` will be used to check for
-existence, while `require.resolve()` will be used for Node.js modules. If found, a result object
-will be returned with the resolved [`Path`][path] and original lookup parts.
+existence, while the [`resolve`](https://www.npmjs.com/package/resolve) npm package will be used for
+Node.js modules. If found, a result object will be returned with the resolved [`Path`][path] and
+original lookup parts.
 
 ```ts
-const { originalPath, resolvedPath, type } = resolver.resolve();
+const { originalPath, resolvedPath, type } = await resolver.resolve();
 ```
 
 If you'd prefer to only have the resolved path returned, the
@@ -298,7 +302,7 @@ If you'd prefer to only have the resolved path returned, the
 instead.
 
 ```ts
-const resolvedPath = resolver.resolvePath();
+const resolvedPath = await resolver.resolvePath();
 ```
 
 [contract]: /api/common/class/Contract

--- a/website/docs/migrate/3.0.md
+++ b/website/docs/migrate/3.0.md
@@ -1,0 +1,52 @@
+# 3.0 migration
+
+- Requires TypeScript v4.4 or greater, as we rely on new syntax and features.
+- Dropped Node.js v10 support. Now requires v12.17 and above.
+- Dropped Internet Explorer 11 support (for packages with browser code). Now requires the latest
+  versions of Edge, Chrome, or Firefox.
+
+## @boost/common
+
+### Removed `parseFile` function
+
+The `parseFile()` function has been removed as it partially relied on `requireModule()`, which has
+also been removed (below).
+
+However, similar functionality can be achieved with the [`json`](/api/common/namespace/json) and
+[`yaml`](/api/common/namespace/yaml) serializers, or simply native `require()`.
+
+```ts
+// Before
+import { parseFile } from '@boost/common';
+
+const contents = parseFile('file.js');
+const contents = parseFile('file.json');
+const contents = parseFile('file.yaml');
+```
+
+```ts
+// After
+import { json, yaml } from '@boost/common';
+
+const contents = require('file.js');
+const contents = json.load('file.json');
+const contents = yaml.load('file.yaml');
+```
+
+### Removed `requireModule` and `requireTypedModule` functions
+
+These functions have moved to the new [`@boost/module`](../module.mdx) package.
+
+```ts
+// Before
+import { requireModule } from '@boost/common';
+
+const result = requireModule('foo');
+```
+
+```ts
+// After
+import { requireModule } from '@boost/module';
+
+const result = requireModule('foo').default;
+```

--- a/website/docs/migrate/3.0.md
+++ b/website/docs/migrate/3.0.md
@@ -7,6 +7,35 @@
 
 ## @boost/common
 
+### Changed `PathResolver` to be async
+
+The [`PathResolver`](/api/common/class/PathResolver) class and its resolve methods were synchronous
+by design (only because `require.resolve()` was). Since we're moving to an "ESM first and only"
+approach, we removed the `require.resolve()` compatibility and updated the resolver signature to be
+async. The resolver also accepts a "starting directory" in which to resolve from.
+
+This change will support the future `import.meta.resolve()` API, but until that lands, the class
+will use the [`resolve`](npmjs.com/resolve) npm package internally.
+
+```ts
+// Before
+import { PathResolver } from '@boost/common';
+
+const resolver = new PathResolver();
+const path = resolver.resolve();
+```
+
+```ts
+// After
+import { PathResolver } from '@boost/common';
+
+const resolver = new PathResolver();
+const path = await resolver.resolve(__dirname);
+```
+
+> If you require a synchronous API, unfortunately, you will need to implement that functionality
+> yourself.
+
 ### Removed `parseFile` function
 
 The `parseFile()` function has been removed as it partially relied on `requireModule()`, which has

--- a/yarn.lock
+++ b/yarn.lock
@@ -1989,10 +1989,12 @@ __metadata:
     "@boost/decorators": ^3.0.0-alpha.0
     "@boost/internal": ^3.0.0-alpha.0
     "@boost/test-utils": ^3.0.0-alpha.0
+    "@types/resolve": ^1.20.1
     fast-glob: ^3.2.7
     json5: ^2.2.0
     optimal: ^4.3.0
     pretty-ms: ^7.0.1
+    resolve: ^1.20.0
     yaml: ^1.10.2
   peerDependencies:
     typescript: ^4.0.0
@@ -4691,6 +4693,13 @@ __metadata:
     "@types/scheduler": "*"
     csstype: ^3.0.2
   checksum: 8b3e543bcde1f244246dff0a73ef604880514799a9e8c0d1371d3ac79f0b6b1e5aef27fa28a5bb66991e28662764bc40bff926de07762e8d5ff480bb372dc1de
+  languageName: node
+  linkType: hard
+
+"@types/resolve@npm:^1.20.1":
+  version: 1.20.1
+  resolution: "@types/resolve@npm:1.20.1"
+  checksum: d035d5aaadbd455027fa9457a4a263563d49647f088876aebd2b0388d4c35400b85c0382fdc2ec5253c35442abfc2d25431c989345b97fefe26a367811214343
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
In preparation for ESM code that is always async by design.