### PR TITLE
breaking: Update `Project` to use `Path`s.

### DIFF
--- a/packages/common/src/ModulePath.ts
+++ b/packages/common/src/ModulePath.ts
@@ -74,7 +74,7 @@ export class ModulePath implements Pathable {
 			return null;
 		}
 
-		return this.internalPath.slice(0, this.internalPath.indexOf('/'));
+		return this.path().slice(0, this.path().indexOf('/'));
 	}
 
 	toJSON(): ModuleID {

--- a/packages/common/src/ModulePath.ts
+++ b/packages/common/src/ModulePath.ts
@@ -10,8 +10,7 @@ export class ModulePath implements Pathable {
 	private isNormalized: boolean = false;
 
 	constructor(...parts: PortablePath[]) {
-		this.internalPath =
-			parts.length === 1 ? String(parts[0]) || '.' : path.join(...parts.map(String));
+		this.internalPath = path.join(...parts.map(String));
 	}
 
 	/**

--- a/packages/common/src/Path.ts
+++ b/packages/common/src/Path.ts
@@ -15,8 +15,7 @@ export class Path implements Pathable {
 	private isNormalized: boolean = false;
 
 	constructor(...parts: PortablePath[]) {
-		this.internalPath =
-			parts.length === 1 ? String(parts[0]) || '.' : path.join(...parts.map(String));
+		this.internalPath = path.join(...parts.map(String));
 	}
 
 	/**

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -180,10 +180,10 @@ export interface PackageGraphTree<T extends PackageStructure> {
 // WORKSPACES
 
 export interface WorkspaceMetadata {
-	jsonPath: string;
-	packagePath: string;
+	jsonPath: Path;
+	packagePath: Path;
 	packageName: string;
-	workspacePath: string;
+	workspacePath: Path;
 	workspaceName: string;
 }
 

--- a/packages/common/tests/Project.test.ts
+++ b/packages/common/tests/Project.test.ts
@@ -79,19 +79,19 @@ describe('Project', () => {
 				{
 					package: { name: 'test-boost-workspace-multiple-baz', version: '0.0.0' },
 					metadata: project.createWorkspaceMetadata(
-						rootPath.append(normalizeSeparators('packages/baz/package.json')).path(),
+						rootPath.append(normalizeSeparators('packages/baz/package.json')),
 					),
 				},
 				{
 					package: { name: 'test-boost-workspace-multiple-foo', version: '0.0.0' },
 					metadata: project.createWorkspaceMetadata(
-						rootPath.append(normalizeSeparators('packages/foo/package.json')).path(),
+						rootPath.append(normalizeSeparators('packages/foo/package.json')),
 					),
 				},
 				{
 					package: { name: 'test-boost-workspace-multiple-bar', version: '0.0.0' },
 					metadata: project.createWorkspaceMetadata(
-						rootPath.append(normalizeSeparators('modules/bar/package.json')).path(),
+						rootPath.append(normalizeSeparators('modules/bar/package.json')),
 					),
 				},
 			]);
@@ -105,7 +105,7 @@ describe('Project', () => {
 				{
 					package: { name: 'test-boost-workspace-foo-yarn', version: '0.0.0' },
 					metadata: project.createWorkspaceMetadata(
-						rootPath.append(normalizeSeparators('packages/foo/package.json')).path(),
+						rootPath.append(normalizeSeparators('packages/foo/package.json')),
 					),
 				},
 			]);
@@ -119,7 +119,7 @@ describe('Project', () => {
 				{
 					package: { name: 'test-boost-workspace-foo-lerna', version: '0.0.0' },
 					metadata: project.createWorkspaceMetadata(
-						rootPath.append(normalizeSeparators('packages/foo/package.json')).path(),
+						rootPath.append(normalizeSeparators('packages/foo/package.json')),
 					),
 				},
 			]);
@@ -133,7 +133,7 @@ describe('Project', () => {
 				{
 					package: { name: 'test-boost-workspace-foo-pnpm', version: '0.0.0' },
 					metadata: project.createWorkspaceMetadata(
-						rootPath.append(normalizeSeparators('packages/foo/package.json')).path(),
+						rootPath.append(normalizeSeparators('packages/foo/package.json')),
 					),
 				},
 			]);
@@ -153,20 +153,24 @@ describe('Project', () => {
 			);
 		});
 
-		// it('returns an array of all packages within all workspaces', () => {
-		// 	expect(new Project(getFixturePath('workspace-multiple')).getWorkspacePackagePaths()).toEqual([
-		// 		getFixturePath('workspace-multiple', 'packages/baz'),
-		// 		getFixturePath('workspace-multiple', 'packages/foo'),
-		// 		getFixturePath('workspace-multiple', 'modules/bar'),
-		// 	]);
-		// });
+		it('returns an array of all packages within all workspaces', () => {
+			expect(new Project(getFixturePath('workspace-multiple')).getWorkspacePackagePaths()).toEqual([
+				mockFilePath(getFixturePath('workspace-multiple', 'packages/baz')),
+				mockFilePath(getFixturePath('workspace-multiple', 'packages/foo')),
+				mockFilePath(getFixturePath('workspace-multiple', 'modules/bar')),
+			]);
+		});
 
-		// it('returns an array of all packages within all workspaces as relative paths', () => {
-		// 	expect(
-		// 		new Project(getFixturePath('workspace-multiple')).getWorkspacePackagePaths({
-		// 			relative: true,
-		// 		}),
-		// 	).toEqual(['packages/baz', 'packages/foo', 'modules/bar']);
-		// });
+		it('returns an array of all packages within all workspaces as relative paths', () => {
+			expect(
+				new Project(getFixturePath('workspace-multiple')).getWorkspacePackagePaths({
+					relative: true,
+				}),
+			).toEqual([
+				mockFilePath('packages/baz'),
+				mockFilePath('packages/foo'),
+				mockFilePath('modules/bar'),
+			]);
+		});
 	});
 });

--- a/packages/common/tests/Project.test.ts
+++ b/packages/common/tests/Project.test.ts
@@ -1,6 +1,6 @@
 import { getFixturePath } from '@boost/test-utils';
 import { Path, Project } from '../src';
-import { mockFilePath, normalizeSeparators } from '../src/test';
+import { mockFilePath, mockNormalizedFilePath, normalizeSeparators } from '../src/test';
 
 describe('Project', () => {
 	describe('getProject()', () => {
@@ -154,6 +154,8 @@ describe('Project', () => {
 		});
 
 		it('returns an array of all packages within all workspaces', () => {
+			console.log(new Project(getFixturePath('workspace-multiple')).getWorkspacePackagePaths());
+
 			expect(new Project(getFixturePath('workspace-multiple')).getWorkspacePackagePaths()).toEqual([
 				mockFilePath(getFixturePath('workspace-multiple', 'packages/baz')),
 				mockFilePath(getFixturePath('workspace-multiple', 'packages/foo')),
@@ -162,6 +164,12 @@ describe('Project', () => {
 		});
 
 		it('returns an array of all packages within all workspaces as relative paths', () => {
+			console.log(
+				new Project(getFixturePath('workspace-multiple')).getWorkspacePackagePaths({
+					relative: true,
+				}),
+			);
+
 			expect(
 				new Project(getFixturePath('workspace-multiple')).getWorkspacePackagePaths({
 					relative: true,

--- a/website/docs/migrate/3.0.md
+++ b/website/docs/migrate/3.0.md
@@ -7,7 +7,7 @@
 
 ## @boost/common
 
-### Changed `Path` to be more performant and OS compliant
+### Updated `Path` to be more performant and OS compliant
 
 The [`Path`](/api/common/class/PathResolver) class was designed as an abstraction around file system
 and Node.js module paths to provide seamless interoperability between different operating systems.
@@ -18,8 +18,8 @@ changes have been made:
 
 - Path separators are no longer forced to `/` and instead will be OS native: `/` on POSIX, `\` on
   Windows.
-- Path normalization is now deferred until the `path()` method is called, instead of being called on
-  every `Path` instantiation.
+- Path normalization is now deferred until the [`Path#path()`](/api/common/class/Path#path) method
+  is called, instead of being called on every `Path` instantiation.
 
 While this change was beneficial for file system paths, it had the unfortunate side-effect of
 breaking all Node.js module `Path`s, as they must always use forward slashes `/`. To remedy this, a
@@ -60,7 +60,7 @@ expect(somePathInstance).toEqual(mockFilePath('some/file/system/path'));
 expect(somePathInstance.path()).toBe(normalizeSeparators('some/file/system/path'));
 ```
 
-### Changed `PathResolver` to be async
+### Updated `PathResolver` to be async
 
 The [`PathResolver`](/api/common/class/PathResolver) class and its resolve methods were synchronous
 by design (only because `require.resolve()` was). Since we're moving to an "ESM first and only"
@@ -88,6 +88,26 @@ const path = await resolver.resolve(__dirname);
 
 > If you require a synchronous API, unfortunately, you will need to implement that functionality
 > yourself.
+
+### Updated `Project` to use path instances
+
+All methods on [`Project`](/api/common/class/Project) that returned file system paths, will now
+return a [`Path`](/api/common/class/Path) instance instead of a string.
+
+```ts
+// Before
+project.getWorkspacePackagePaths().map((path) => new Path(path, 'src/index.ts'));
+```
+
+```ts
+// After
+project.getWorkspacePackagePaths().map((path) => path.append('src/index.ts'));
+```
+
+The exception to this is
+[`Project#getWorkspaceGlobs()`](/api/common/class/Project#getWorkspaceGlobs), which returns a list
+of strings, since these are glob patterns _and not_ file paths (even though they look similar).
+Furthermore, glob patterns will _always_ use forward slashes, regardless of operating system.
 
 ### Removed `parseFile` function
 


### PR DESCRIPTION
Updates all `Project` methods to return `Path`s.