### PR TITLE
new: Support the new loader API.

### DIFF
--- a/packages/module/loader.mjs
+++ b/packages/module/loader.mjs
@@ -1,1 +1,1 @@
-export { getFormat, resolve, transformSource } from './mjs/loader.mjs';
+export { getFormat, load, resolve, transformSource } from './mjs/loader.mjs';

--- a/packages/module/src/loaders/index.ts
+++ b/packages/module/src/loaders/index.ts
@@ -11,4 +11,4 @@ export { typescript };
 // Since we only have 1 loader at the moment, just return it directly.
 // Once we have multiple loaders, we can iterate through them as a whole.
 
-export const { resolve, getFormat, transformSource } = typescript;
+export const { getFormat, load, resolve, transformSource } = typescript;

--- a/packages/module/src/types.ts
+++ b/packages/module/src/types.ts
@@ -47,6 +47,26 @@ export type LoaderResolve = (
 	defaultResolve: LoaderDefaultResolve,
 ) => Promise<ResolveResult>;
 
+export interface LoadContext {
+	format: string | null | undefined;
+	importAssertions?: object;
+}
+
+export interface LoadResult {
+	format: string;
+	source?: ArrayBuffer | string;
+}
+
+export type LoaderDefaultLoad = (url: string, context: LoadContext) => Promise<LoadResult>;
+
+export type LoaderLoad = (
+	url: string,
+	context: LoadContext,
+	defaultLoad: LoaderDefaultLoad,
+) => Promise<LoadResult>;
+
+// LEGACY LOADERS
+
 export type GetFormatContext = Record<string, unknown>;
 
 export interface GetFormatResult {

--- a/packages/module/src/typescript.ts
+++ b/packages/module/src/typescript.ts
@@ -9,18 +9,26 @@ export const COMPILER_OPTIONS = {
 	noEmit: true,
 };
 
+export const NODE_VERSION = Number.parseFloat(process.version.slice(1));
+
 export function isTypeScript(path: string) {
 	return path.endsWith('.ts') || path.endsWith('.tsx');
 }
 
-export function getModuleFromNodeVersion(ts: TS) {
-	const version = Number.parseFloat(process.version.slice(1));
+export function getModuleFormat(url: string) {
+	if (url.endsWith('.json')) {
+		return 'json';
+	}
 
-	if (version >= 15) {
+	return NODE_VERSION >= 12 ? 'module' : 'commonjs';
+}
+
+export function getModuleFromNodeVersion(ts: TS) {
+	if (NODE_VERSION >= 15) {
 		return ts.ModuleKind.ES2020;
 	}
 
-	if (version >= 12) {
+	if (NODE_VERSION >= 12) {
 		return ts.ModuleKind.ES2015;
 	}
 
@@ -28,25 +36,23 @@ export function getModuleFromNodeVersion(ts: TS) {
 }
 
 export function getTargetFromNodeVersion(ts: TS) {
-	const version = Number.parseFloat(process.version.slice(1));
-
-	if (version >= 16) {
+	if (NODE_VERSION >= 16) {
 		return ts.ScriptTarget.ES2020;
 	}
 
-	if (version >= 15) {
+	if (NODE_VERSION >= 15) {
 		return ts.ScriptTarget.ES2019;
 	}
 
-	if (version >= 14) {
+	if (NODE_VERSION >= 14) {
 		return ts.ScriptTarget.ES2018;
 	}
 
-	if (version >= 13) {
+	if (NODE_VERSION >= 13) {
 		return ts.ScriptTarget.ES2017;
 	}
 
-	if (version >= 12) {
+	if (NODE_VERSION >= 12) {
 		return ts.ScriptTarget.ES2016;
 	}
 


### PR DESCRIPTION
The API has been streamlined into a single `load` method: https://nodejs.org/api/esm.html#hooks