### PR TITLE
new: Support `<name>.config.<ext>` style root configs.

### DIFF
--- a/packages/config/src/Cache.ts
+++ b/packages/config/src/Cache.ts
@@ -41,8 +41,12 @@ export class Cache {
 		return content;
 	}
 
-	async cacheFilesInDir(dir: Path, commit: () => Promise<Path[]>): Promise<Path[]> {
-		const key = dir.path();
+	async cacheFilesInDir(
+		dir: Path,
+		commit: () => Promise<Path[]>,
+		keyHash: string = '',
+	): Promise<Path[]> {
+		const key = dir.path() + keyHash;
 
 		if (this.dirFilesCache[key]) {
 			return this.dirFilesCache[key];

--- a/packages/config/src/Cache.ts
+++ b/packages/config/src/Cache.ts
@@ -10,6 +10,8 @@ export interface FileCache<T> {
 export class Cache {
 	configDir?: Path;
 
+	configFile?: Path;
+
 	dirFilesCache: Record<string, Path[]> = {};
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/config/src/ConfigError.ts
+++ b/packages/config/src/ConfigError.ts
@@ -5,7 +5,9 @@ const errors = {
 	EXTENDS_UNKNOWN_PATH: 'Cannot extend configuration. Unknown module or file path "{0}".',
 	LOADER_UNSUPPORTED: 'Unsupported loader format "{0}".',
 	PACKAGE_UNKNOWN_SCOPE: 'Unable to determine package scope. No parent `package.json` found.',
-	ROOT_INVALID: 'Invalid configuration root. Requires a `{0}` folder and `package.json`.',
+	ROOT_FILE_ONLY_ONE: 'Only 1 root config file may exist, found {0}.',
+	ROOT_INVALID:
+		'Invalid configuration root. Requires a `{0}` folder and `package.json`, OR a `{1}.config.*` file.',
 	ROOT_NO_PACKAGE:
 		'Config folder `{0}` found without a relative `package.json`. Both must be located in the project root.',
 	ROOT_ONLY_OVERRIDES: 'Overrides setting `{0}` must only be defined in a root config.',

--- a/packages/config/src/ConfigFinder.ts
+++ b/packages/config/src/ConfigFinder.ts
@@ -12,7 +12,13 @@ import {
 import { Blueprint, Schemas } from '@boost/common/optimal';
 import { color } from '@boost/internal';
 import { ConfigError } from './ConfigError';
-import { CONFIG_FOLDER, DEFAULT_EXTS, PACKAGE_FILE } from './constants';
+import {
+	CONFIG_FOLDER,
+	DEFAULT_EXTS,
+	PACKAGE_FILE,
+	ROOT_CONFIG_DIR_REGEX,
+	ROOT_CONFIG_FILE_REGEX,
+} from './constants';
 import { Finder } from './Finder';
 import { createFileName } from './helpers/createFileName';
 import { getEnv } from './helpers/getEnv';
@@ -92,7 +98,7 @@ export class ConfigFinder<T extends object> extends Finder<ConfigFile<T>, Config
 	 * Will only search until the first file is found, and will not return multiple extensions.
 	 */
 	async findFilesInDir(dir: Path): Promise<Path[]> {
-		const isRoot = this.isRootDir(dir);
+		const isRoot = await this.isRootDir(dir);
 		const baseDir = isRoot ? dir.append(CONFIG_FOLDER) : dir;
 
 		return this.cache.cacheFilesInDir(baseDir, async () => {
@@ -344,10 +350,13 @@ export class ConfigFinder<T extends object> extends Finder<ConfigFile<T>, Config
 			}
 		});
 
+		const isRoot =
+			ROOT_CONFIG_DIR_REGEX.test(path.path()) || ROOT_CONFIG_FILE_REGEX.test(path.path());
+
 		return {
 			config,
 			path,
-			source: source ?? (path.path().includes(CONFIG_FOLDER) ? 'root' : 'branch'),
+			source: source ?? (isRoot ? 'root' : 'branch'),
 		};
 	}
 }

--- a/packages/config/src/Finder.ts
+++ b/packages/config/src/Finder.ts
@@ -79,22 +79,25 @@ export abstract class Finder<
 	}
 
 	protected async hasRootFile(dir: Path): Promise<Path | null> {
-		const results = await this.cache.cacheFilesInDir(dir, async () => {
-			const files = await new Promise<string[]>((resolve, reject) => {
-				fs.readdir(dir.path(), (error, list) => {
-					if (error) {
-						reject(error);
-					} else {
-						resolve(list);
-					}
+		const results = await this.cache.cacheFilesInDir(
+			dir,
+			async () => {
+				const files = await new Promise<string[]>((resolve, reject) => {
+					fs.readdir(dir.path(), (error, list) => {
+						if (error) {
+							reject(error);
+						} else {
+							resolve(list);
+						}
+					});
 				});
-			});
 
-			console.log(files);
-
-			// Filter down to files that match our root config format
-			return files.filter((file) => ROOT_CONFIG_FILE_REGEX.test(file)).map(Path.create);
-		});
+				// Filter down to files that match our root config format
+				return files.filter((file) => ROOT_CONFIG_FILE_REGEX.test(file)).map(Path.create);
+			},
+			// We need a key here to differentiate between normal file cache lookups
+			'#rootConfigFile',
+		);
 
 		if (results.length > 1) {
 			throw new ConfigError('ROOT_FILE_ONLY_ONE', [results.length]);

--- a/packages/config/src/IgnoreFinder.ts
+++ b/packages/config/src/IgnoreFinder.ts
@@ -62,7 +62,9 @@ export class IgnoreFinder extends Finder<IgnoreFile, IgnoreFinderOptions> {
 				return {
 					ignore,
 					path: filePath,
-					source: this.isRootDir(filePath.parent(), true) ? ('root' as const) : ('branch' as const),
+					source: (await this.isRootDir(filePath.parent(), true))
+						? ('root' as const)
+						: ('branch' as const),
 				};
 			}),
 		);

--- a/packages/config/src/constants.ts
+++ b/packages/config/src/constants.ts
@@ -2,6 +2,10 @@ import { ExtType } from './types';
 
 export const CONFIG_FOLDER = '.config';
 
+export const ROOT_CONFIG_DIR_REGEX = /\.config([/\\])([\d.a-z]+)\.([\da-z]{2,5})$/i;
+
+export const ROOT_CONFIG_FILE_REGEX = /([\da-z]+)\.config\.([\da-z]{2,5})$/i;
+
 export const PACKAGE_FILE = 'package.json';
 
 export const DEFAULT_EXTS: ExtType[] = ['js', 'json', 'cjs', 'mjs', 'ts', 'json5', 'yaml', 'yml'];

--- a/packages/config/tests/ConfigFinder.test.ts
+++ b/packages/config/tests/ConfigFinder.test.ts
@@ -608,7 +608,7 @@ describe('ConfigFinder', () => {
 			const tempRoot = getFixturePath('config-scenario-not-root');
 
 			await expect(finder.loadFromRoot(tempRoot)).rejects.toThrow(
-				'Invalid configuration root. Requires a `.config` folder and `package.json`.',
+				'Invalid configuration root. Requires a `.config` folder and `package.json`, OR a `boost.config.*` file.',
 			);
 		});
 

--- a/packages/config/tests/IgnoreFinder.test.ts
+++ b/packages/config/tests/IgnoreFinder.test.ts
@@ -30,7 +30,6 @@ describe('IgnoreFinder', () => {
 		expect(cache.rootDir).toEqual(mockSystemPath(tempRoot));
 		expect(cache.configDir).toEqual(mockSystemPath(`${tempRoot}/.config`));
 		expect(cache.pkgPath).toEqual(mockSystemPath(`${tempRoot}/package.json`));
-		expect(cache.dirFilesCache).toEqual({});
 		expect(cache.fileContentCache).toEqual({
 			[mockSystemPath(`${tempRoot}/.boostignore`).path()]: {
 				content: `*.log${EOL}*.lock`,
@@ -118,7 +117,7 @@ describe('IgnoreFinder', () => {
 			const tempRoot = getFixturePath('config-ignore-file-tree');
 
 			await expect(finder.loadFromRoot(normalizeSeparators(`${tempRoot}/src`))).rejects.toThrow(
-				'Invalid configuration root. Requires a `.config` folder and `package.json`.',
+				'Invalid configuration root. Requires a `.config` folder and `package.json`, OR a `boost.config.*` file.',
 			);
 		});
 

--- a/website/docs/config.mdx
+++ b/website/docs/config.mdx
@@ -195,15 +195,15 @@ structure.
 
 ### File patterns
 
-Config files are grouped into either the root or branch category. Root config files are located in a
-`.config` folder in the root of a project (denoted by the current working directory). Branch config
-files are located within folders (at any depth) below the root, and are prefixed with a leading dot
-(`.`).
+Config files are grouped into either the root or branch category. The root of a project is denoted
+by a root `*.config.*` file, or a folder with the name `.config`, which contains config files.
+Branch config files are located within folders (at any depth) below the root, and are prefixed with
+a leading dot (`.`).
 
-| Root                         | Branch                |
-| ---------------------------- | --------------------- |
-| `.config/<name>.<ext>`       | `.<name>.<ext>`       |
-| `.config/<name>.<env>.<ext>` | `.<name>.<env>.<ext>` |
+| Root                                                      | Branch                |
+| --------------------------------------------------------- | --------------------- |
+| `.config/<name>.<ext>`, `<name>.config.<ext>`             | `.<name>.<ext>`       |
+| `.config/<name>.<env>.<ext>`, `<name>.config.<env>.<ext>` | `.<name>.<env>.<ext>` |
 
 - `<name>` - Name passed to your [`Configuration`][configuration] instance (in camel case).
 - `<env>` - Current environment derived from `NODE_ENV`.
@@ -357,8 +357,8 @@ Once a file is found, the lookup process is aborted, and the confg is returned.
 #### From root
 
 The [`Configuration#loadConfigFromRoot()`][loadconfigfromroot] will load the config file found in
-the root `.config` folder (typically 1 file). If no root path is provided, it defaults to
-process.cwd().
+the root, either a `*.config.*` or `.config/*.*` file. If no root path is provided, it defaults to
+`process.cwd()`.
 
 ```json title="root/.config/boost.json"
 {
@@ -382,10 +382,6 @@ const { config } = await manager.loadConfigFromRoot('/root');
   ],
 }
 ```
-
-> Why are root config files located within a `.config` folder? In an effort to reduce the root
-> config and dotfile churn that many projects suffer from, we're trying to push forward an idiomatic
-> standard that we hope many others will follow.
 
 #### From branch
 


### PR DESCRIPTION
Might as well support both patterns since `.config` hasn't taken off in the ecosystem.