### PR TITLE
new: Add `Configuration#findRootDir` and `setRootDir` methods.

### DIFF
--- a/packages/config/src/Cache.ts
+++ b/packages/config/src/Cache.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
-import { Path } from '@boost/common';
+import { Path, PortablePath } from '@boost/common';
+import { ConfigError } from './ConfigError';
 
 export interface FileCache<T> {
 	content: T;
@@ -71,6 +72,18 @@ export class Cache {
 			exists: false,
 			mtime: 0,
 		};
+
+		return this;
+	}
+
+	setRootDir(dir: PortablePath): this {
+		const root = Path.resolve(dir);
+
+		if (!root.isDirectory()) {
+			throw new ConfigError('ROOT_INVALID_DIR');
+		}
+
+		this.rootDir = root;
 
 		return this;
 	}

--- a/packages/config/src/ConfigError.ts
+++ b/packages/config/src/ConfigError.ts
@@ -6,6 +6,7 @@ const errors = {
 	LOADER_UNSUPPORTED: 'Unsupported loader format "{0}".',
 	PACKAGE_UNKNOWN_SCOPE: 'Unable to determine package scope. No parent `package.json` found.',
 	ROOT_INVALID: 'Cannot find root configuration. Requires a `{0}` folder or a `{1}.config.*` file.',
+	ROOT_INVALID_DIR: 'Root must be a directory.',
 	ROOT_NO_PACKAGE:
 		'Config folder `{0}` found without a relative `package.json`. Both must be located in the project root.',
 	ROOT_ONLY_OVERRIDES: 'Overrides setting `{0}` must only be defined in a root config.',

--- a/packages/config/src/Configuration.ts
+++ b/packages/config/src/Configuration.ts
@@ -2,7 +2,6 @@ import { Contract, ModuleResolver, Path, PortablePath } from '@boost/common';
 import { Blueprint, schemas } from '@boost/common/optimal';
 import { Event, WaterfallEvent } from '@boost/event';
 import { Cache } from './Cache';
-import { ConfigError } from './ConfigError';
 import { ConfigFinder } from './ConfigFinder';
 import { IgnoreFinder } from './IgnoreFinder';
 import { Processor } from './Processor';
@@ -138,13 +137,7 @@ export abstract class Configuration<T extends object> extends Contract<T> {
 	 * This *does not* check for the existence of the root config file or folder.
 	 */
 	setRootDir(dir: PortablePath): this {
-		const root = Path.resolve(dir);
-
-		if (!root.isDirectory()) {
-			throw new ConfigError('ROOT_INVALID_DIR');
-		}
-
-		this.cache.rootDir = root;
+		this.cache.setRootDir(dir);
 
 		return this;
 	}

--- a/packages/config/src/Configuration.ts
+++ b/packages/config/src/Configuration.ts
@@ -2,6 +2,7 @@ import { Contract, ModuleResolver, Path, PortablePath } from '@boost/common';
 import { Blueprint, schemas } from '@boost/common/optimal';
 import { Event, WaterfallEvent } from '@boost/event';
 import { Cache } from './Cache';
+import { ConfigError } from './ConfigError';
 import { ConfigFinder } from './ConfigFinder';
 import { IgnoreFinder } from './IgnoreFinder';
 import { Processor } from './Processor';
@@ -128,6 +129,24 @@ export abstract class Configuration<T extends object> extends Contract<T> {
 		const ignores = await this.getIgnoreFinder().loadFromRoot(dir);
 
 		return this.onLoadedIgnore.emit(ignores);
+	}
+
+	/**
+	 * Explicitly set the root directory to stop traversal at. This should only be set
+	 * manually when you want full control, and know file boundaries up front.
+	 *
+	 * This *does not* check for the existence of the root config file or folder.
+	 */
+	setRootDir(dir: PortablePath): this {
+		const root = Path.resolve(dir);
+
+		if (!root.isDirectory()) {
+			throw new ConfigError('ROOT_INVALID_DIR');
+		}
+
+		this.cache.rootDir = root;
+
+		return this;
 	}
 
 	/**

--- a/packages/config/src/Configuration.ts
+++ b/packages/config/src/Configuration.ts
@@ -1,4 +1,4 @@
-import { Contract, ModuleResolver, PortablePath } from '@boost/common';
+import { Contract, ModuleResolver, Path, PortablePath } from '@boost/common';
 import { Blueprint, schemas } from '@boost/common/optimal';
 import { Event, WaterfallEvent } from '@boost/event';
 import { Cache } from './Cache';
@@ -80,6 +80,15 @@ export abstract class Configuration<T extends object> extends Contract<T> {
 	}
 
 	/**
+	 * Attempt to find the root directory starting from the provided directory.
+	 * Once the root is found, it will be cached for further lookups,
+	 * otherwise an error is thrown based on current configuration.
+	 */
+	async findRootDir(fromDir: PortablePath = process.cwd()): Promise<Path> {
+		return this.getConfigFinder().findRootDir(fromDir);
+	}
+
+	/**
 	 * Traverse upwards from the branch directory, until the root directory is found,
 	 * or we reach to top of the file system. While traversing, find all config files
 	 * within each branch directory, and the root.
@@ -94,8 +103,8 @@ export abstract class Configuration<T extends object> extends Contract<T> {
 	 * Load config files from the defined root. Root is determined by a relative
 	 * `.config` folder and `package.json` file.
 	 */
-	async loadConfigFromRoot(dir: PortablePath = process.cwd()): Promise<ProcessedConfig<T>> {
-		const configs = await this.getConfigFinder().loadFromRoot(dir);
+	async loadConfigFromRoot(fromDir: PortablePath = process.cwd()): Promise<ProcessedConfig<T>> {
+		const configs = await this.getConfigFinder().loadFromRoot(fromDir);
 
 		return this.processConfigs(this.onLoadedConfig.emit(configs));
 	}

--- a/packages/config/src/Finder.ts
+++ b/packages/config/src/Finder.ts
@@ -41,7 +41,7 @@ export abstract class Finder<
 				// let's just assume the current working directory is the root.
 				const cwd = Path.create(process.cwd());
 
-				this.cache.rootDir = cwd;
+				this.cache.setRootDir(cwd);
 
 				return cwd;
 			}
@@ -60,7 +60,7 @@ export abstract class Finder<
 						throw new ConfigError('ROOT_NO_PACKAGE', [CONFIG_FOLDER]);
 					}
 
-					this.cache.rootDir = dir;
+					this.cache.setRootDir(dir);
 					this.cache.configDir = configDir;
 					this.cache.pkgPath = pkgPath;
 
@@ -69,7 +69,7 @@ export abstract class Finder<
 			}
 
 			if (ROOT_CONFIG_FILE_REGEX.test(file)) {
-				this.cache.rootDir = dir;
+				this.cache.setRootDir(dir);
 
 				break;
 			}


### PR DESCRIPTION
This gives consumers some control over the "root" of their project.